### PR TITLE
Feature/install alb controller

### DIFF
--- a/python-lib/dku_aws/aws_command.py
+++ b/python-lib/dku_aws/aws_command.py
@@ -12,12 +12,16 @@ class AwsCommand(object):
         if _has_not_blank_property(connection_info, 'region'):
             self.env['AWS_DEFAULT_REGION'] = connection_info['region']
         
-    def run_and_get_output(self):
+    def run(self):
         cmd = ["aws"] + self.args
         print('Running %s' % (' '.join(cmd)))
         p = subprocess.Popen(cmd, shell=False, env=self.env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (o, e) = p.communicate()
-        return o
+        rv = p.wait()
+        return (cmd, rv, o, e)
+    
+    def run_and_get_output(self):
+        return self.run()[2]
     
     def run_and_log(self):
         cmd = ["aws"] + self.args

--- a/python-lib/dku_aws/eksctl_command.py
+++ b/python-lib/dku_aws/eksctl_command.py
@@ -14,12 +14,16 @@ class EksctlCommand(object):
         if _has_not_blank_property(connection_info, 'region'):
             self.env['AWS_DEFAULT_REGION'] = connection_info['region']
         
-    def run_and_get_output(self):
+    def run(self):
         cmd = [self.eksctl_bin] + self.args
         print('Running %s' % (' '.join(cmd)))
         p = subprocess.Popen(cmd, shell=False, env=self.env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (o, e) = p.communicate()
-        return o
+        rv = p.wait()
+        return (cmd, rv, o, e)
+    
+    def run_and_get_output(self):
+        return self.run()[2]
     
     def run_and_log(self):
         cmd = [self.eksctl_bin] + self.args

--- a/python-lib/dku_kube/kubectl_command.py
+++ b/python-lib/dku_kube/kubectl_command.py
@@ -1,10 +1,11 @@
 import os, sys, json, yaml, logging, subprocess, time
 
 class KubeCommandException(Exception):
-    def __init__(self, message, out, err):
+    def __init__(self, message, out, err, rv):
         super(KubeCommandException, self).__init__(message)
         self.out = out
         self.err = err
+        self.rv = rv
         
 def run_with_timeout(cmd, env=None, timeout=3, nokill=False):
     p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
@@ -21,7 +22,7 @@ def run_with_timeout(cmd, env=None, timeout=3, nokill=False):
     out, err = p.communicate()
     rv = p.wait()
     if rv != 0:
-        raise KubeCommandException("Command failed with %s" % rv, out, err)
+        raise KubeCommandException("Command failed with %s" % rv, out, err, rv)
     return out, err
 
 

--- a/python-lib/dku_utils/cluster.py
+++ b/python-lib/dku_utils/cluster.py
@@ -40,3 +40,24 @@ def get_cluster_from_dss_cluster(dss_cluster_id):
 
     return cluster_data, dss_cluster_settings, dss_cluster_config
     
+def get_cluster_generic_property(dss_cluster_settings, key, default_value=None):
+    props = dss_cluster_settings.settings['containerSettings']['executionConfigsGenericOverrides']['properties']
+    found_value = default_value
+    for prop in props:
+        if prop['key'] == key:
+            found_value = prop['value']
+    return found_value
+
+def set_cluster_generic_property(dss_cluster_settings, key, value, replace_if_exists=False):
+    props = dss_cluster_settings.settings['containerSettings']['executionConfigsGenericOverrides']['properties']
+    found_prop = None
+    for prop in props:
+        if prop['key'] == key:
+            found_prop = prop
+    if found_prop is None:
+        props.append({'key':key, 'value':value})
+        dss_cluster_settings.save()
+    elif replace_if_exists:
+        found_prop['value'] = value
+        dss_cluster_settings.save()
+        

--- a/python-runnables/install-alb-controller/runnable.json
+++ b/python-runnables/install-alb-controller/runnable.json
@@ -1,0 +1,35 @@
+{
+     "meta": {
+         "label": "Add ALB controller",
+
+         "description": "Add a controller on the cluster to create ingresses using ALB",
+
+         "icon": "icon-fullscreen"
+     },
+
+     "impersonate": false,
+
+     "macroRoles": [
+         { "type":"CLUSTER", "targetParamsKey":"clusterId", "limitToSamePlugin":true }
+     ],
+
+     "params": [
+         {
+             "name": "policyName",
+             "label": "IAM policy",
+             "type": "STRING",
+             "description": "Name of a policy to use or create (default: ALBIngressControllerIAMPolicy)",
+             "mandatory": false
+         }
+     ],
+
+     "permissions": [],
+
+     "resultType": "HTML",
+
+     "resultLabel": "Installation output",
+
+     "extension": "txt",
+
+     "mimeType": "text/plain"
+ }

--- a/python-runnables/install-alb-controller/runnable.json
+++ b/python-runnables/install-alb-controller/runnable.json
@@ -2,10 +2,12 @@
      "meta": {
          "label": "Add ALB controller",
 
-         "description": "Add a controller on the cluster to create ingresses using ALB",
+         "description": "Add a controller on the cluster to create ingresses using ALB.",
 
          "icon": "icon-fullscreen"
      },
+    
+     "longDescription": "Note: the VPC subnets that the ALB instances will use need to be tagged with *kubernetes.io/role/internal-elb* and *kubernetes.io/role/elb* to *1*",
 
      "impersonate": false,
 

--- a/python-runnables/install-alb-controller/runnable.json
+++ b/python-runnables/install-alb-controller/runnable.json
@@ -7,7 +7,7 @@
          "icon": "icon-fullscreen"
      },
     
-     "longDescription": "Note: the VPC subnets that the ALB instances will use need to be tagged with *kubernetes.io/role/internal-elb* and *kubernetes.io/role/elb* to *1*",
+     "longDescription": "Note: the VPC subnets that the ALB instances will use need to be tagged with \n\n * kubernetes.io/role/internal-elb &rightarrow; 1 \n\n * kubernetes.io/role/elb &rightarrow; 1 ",
 
      "impersonate": false,
 
@@ -22,6 +22,13 @@
              "type": "STRING",
              "description": "Name of a policy to use or create (default: ALBIngressControllerIAMPolicy)",
              "mandatory": false
+         },
+         {
+             "name": "tagSubnets",
+             "label": "Tag subnets",
+             "description": "Tag the subnets of this cluster's settings with kubernetes.io/role/{elb,internal-elb} (for clusters created by this plugin)",
+             "type": "BOOLEAN",
+             "defaultValue": false
          }
      ],
 

--- a/python-runnables/install-alb-controller/runnable.json
+++ b/python-runnables/install-alb-controller/runnable.json
@@ -7,7 +7,7 @@
          "icon": "icon-fullscreen"
      },
     
-     "longDescription": "Note: the VPC subnets that the ALB instances will use need to be tagged with \n\n * kubernetes.io/role/internal-elb &rightarrow; 1 \n\n * kubernetes.io/role/elb &rightarrow; 1 ",
+     "longDescription": ":warning: the ALB ingress controller doesn't work on private clusters\n\nUsage: annotate your ingresses with:\n * kubernetes.io/ingress.class: alb\n * alb.ingress.kubernetes.io/scheme: internet-facing (otherwise the ALB is private)\n\nPrerequisites:\n * the controller needs an IAM policy to spawn ALB instances. Provided the active credentials allow it, the macro can create it according to [the AWS sample](https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.8/docs/examples/iam-policy.json) \n * the VPC subnets that the ALB instances will use need to be tagged with \n   - kubernetes.io/role/internal-elb &rightarrow; 1 \n   - kubernetes.io/role/elb &rightarrow; 1 ",
 
      "impersonate": false,
 
@@ -22,6 +22,14 @@
              "type": "STRING",
              "description": "Name of a policy to use or create (default: ALBIngressControllerIAMPolicy)",
              "mandatory": false
+         },
+         {
+             "name": "createPolicy",
+             "label": "Create if needed",
+             "type": "BOOLEAN",
+             "description": "Create the IAM policy if it doesn't exist",
+             "mandatory": false,
+             "defaultValue": false
          },
          {
              "name": "tagSubnets",

--- a/python-runnables/install-alb-controller/runnable.py
+++ b/python-runnables/install-alb-controller/runnable.py
@@ -93,12 +93,17 @@ class InstallAlb(Runnable):
                 policy_arn = policy.get('Arn', None)
 
         if policy_arn is None:
-            if not self.config("createPolicy", False):
+            if not self.config.get("createPolicy", False):
                 raise Exception("Policy %s doesn't exist and the macro isn't allowed to create it" % policy_name)
             # create the policy
+            policy_document_url = 'https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.8/docs/examples/iam-policy.json'
+            policy_document = requests.get(policy_document_url).text
+            with open("policy.json", "w") as p:
+                p.write(policy_document)
+            
             args = ['iam', 'create-policy']
             args = args + ['--policy-name', policy_name]
-            args = args + ['--policy-document', 'https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.4/docs/examples/iam-policy.json']
+            args = args + ['--policy-document', 'file://policy.json']
             
             if _has_not_blank_property(connection_info, 'region'):
                 args = args + ['--region', connection_info['region']]

--- a/python-runnables/install-alb-controller/runnable.py
+++ b/python-runnables/install-alb-controller/runnable.py
@@ -1,0 +1,165 @@
+from dataiku.runnables import Runnable
+import dataiku
+import json, logging, os, re, tempfile, time
+import requests 
+from dku_aws.eksctl_command import EksctlCommand
+from dku_aws.aws_command import AwsCommand
+from dku_utils.cluster import get_cluster_from_dss_cluster, get_cluster_generic_property, set_cluster_generic_property
+from dku_utils.access import _has_not_blank_property
+from dku_kube.kubectl_command import run_with_timeout, KubeCommandException
+from dku_utils.access import _has_not_blank_property, _is_none_or_blank
+
+def make_html(command_outputs):
+    divs = []
+    for command_output in command_outputs:
+        cmd_html = '<div>Run: %s</div>' % json.dumps(command_output[0])
+        rv_html = '<div>Returned %s</div>' % command_output[1]
+        out_html = '<div class="alert alert-info"><div>Output</div><pre class="debug" style="max-width: 100%%; max-height: 100%%;">%s</pre></div>' % command_output[2]
+        err_html = '<div class="alert alert-danger"><div>Error</div><pre class="debug" style="max-width: 100%%; max-height: 100%%;">%s</pre></div>' % command_output[3]
+        divs.append(cmd_html)
+        divs.append(rv_html)
+        divs.append(out_html)
+        if command_output[1] != 0 and not _is_none_or_blank(command_output[3]):
+            divs.append(err_html)
+    return '\n'.join(divs).decode('utf8')
+
+class InstallNginx(Runnable):
+    """
+    Installs a ALB ingress controller as described in https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html
+    """
+    def __init__(self, project_key, config, plugin_config):
+        self.project_key = project_key
+        self.config = config
+        self.plugin_config = plugin_config
+
+    def get_progress_target(self):
+        return None
+
+    def run(self, progress_callback):
+        cluster_data, dss_cluster_settings, dss_cluster_config = get_cluster_from_dss_cluster(self.config['clusterId'])
+
+        if get_cluster_generic_property(dss_cluster_settings, 'alb-ingress.controller', 'false') == 'true':
+            raise Exception("ALB controller already installed, remove first")
+
+        # retrieve the actual name in the cluster's data
+        if cluster_data is None:
+            raise Exception("No cluster data (not started?)")
+        cluster_def = cluster_data.get("cluster", None)
+        if cluster_def is None:
+            raise Exception("No cluster definition (starting failed?)")
+        cluster_id = cluster_def["Name"]
+        kube_config_path = dss_cluster_settings.get_raw()['containerSettings']['executionConfigsGenericOverrides']['kubeConfigPath']
+        connection_info = dss_cluster_config.get('config', {}).get('connectionInfo', {})
+        
+        env = os.environ.copy()
+        env['KUBECONFIG'] = kube_config_path
+
+        command_outputs = []
+        keep_going = True
+        
+        # setup iam stuff in eksctl
+        args = ['utils', 'associate-iam-oidc-provider', '--approve']
+        #args = args + ['-v', '4']
+        args = args + ['--cluster', cluster_id]
+
+        if _has_not_blank_property(connection_info, 'region'):
+            args = args + ['--region', connection_info['region']]
+        elif 'AWS_DEFAULT_REGION' is os.environ:
+            args = args + ['--region', os.environ['AWS_DEFAULT_REGION']]
+
+        c = EksctlCommand(args, connection_info)
+        command_outputs.append(c.run())
+        if command_outputs[-1][1] != 0:
+            return make_html(command_outputs)
+        
+        # checking if we need to create the policy
+        policy_name = self.config.get('policyName', 'ALBIngressControllerIAMPolicy')
+        
+        args = ['iam', 'list-policies']
+
+        if _has_not_blank_property(connection_info, 'region'):
+            args = args + ['--region', connection_info['region']]
+        elif 'AWS_DEFAULT_REGION' is os.environ:
+            args = args + ['--region', os.environ['AWS_DEFAULT_REGION']]
+
+        c = AwsCommand(args, connection_info)
+        command_outputs.append(c.run())
+        if command_outputs[-1][1] != 0:
+            return make_html(command_outputs)
+        
+        policy_arn = None
+        for policy in json.loads(command_outputs[-1][2])['Policies']:
+            if policy.get('PolicyName', None) == policy_name:
+                policy_arn = policy.get('Arn', None)
+
+        if policy_arn is None:
+            # create the policy
+            args = ['iam', 'create-policy']
+            args = args + ['--policy-name', policy_name]
+            args = args + ['--policy-document', 'https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.4/docs/examples/iam-policy.json']
+            
+            if _has_not_blank_property(connection_info, 'region'):
+                args = args + ['--region', connection_info['region']]
+            elif 'AWS_DEFAULT_REGION' is os.environ:
+                args = args + ['--region', os.environ['AWS_DEFAULT_REGION']]
+
+            c = AwsCommand(args, connection_info)
+            command_outputs.append(c.run())
+            if command_outputs[-1][1] != 0:
+                return make_html(command_outputs)
+            
+            policy_arn = json.loads(command_outputs[-1][2])['Policy'].get('Arn', None)
+
+        # create the role on the cluster
+        cmd = ['kubectl', 'apply', '-f', 'https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.4/docs/examples/rbac-role.yaml']
+        logging.info("Run : %s" % json.dumps(cmd))
+        try:
+            out, err = run_with_timeout(cmd, env=env, timeout=100)
+            command_outputs.append((cmd, 0, out, err))
+        except KubeCommandException as e:
+            command_outputs.append((cmd, e.rv, e.out, e.err))
+            keep_going = False
+
+        if not keep_going:
+            return make_html(command_outputs)
+
+        # attach the role to the policy
+        
+        args = ['create', 'iamserviceaccount', '--override-existing-serviceaccounts', '--approve']
+        #args = args + ['-v', '4']
+        args = args + ['--name', 'alb-ingress-controller'] # that's the name in the rbac-role.yaml
+        args = args + ['--namespace', 'kube-system'] # that's the name in the rbac-role.yaml
+        args = args + ['--cluster', cluster_id]
+        args = args + ['--attach-policy-arn', policy_arn]
+
+        if _has_not_blank_property(connection_info, 'region'):
+            args = args + ['--region', connection_info['region']]
+        elif 'AWS_DEFAULT_REGION' is os.environ:
+            args = args + ['--region', os.environ['AWS_DEFAULT_REGION']]
+
+        c = EksctlCommand(args, connection_info)
+        command_outputs.append(c.run())
+        if command_outputs[-1][1] != 0:
+            return make_html(command_outputs)
+
+        r = requests.get('https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.4/docs/examples/alb-ingress-controller.yaml')
+        service_data = r.content
+        cluster_flag_pattern = '#.*cluster\\-name=.*'
+        cluster_flag_replacement = '- --cluster-name=%s' % cluster_id
+        service_data = re.sub(cluster_flag_pattern, cluster_flag_replacement, service_data)
+        
+        print(service_data)
+        with open('./alb-ingress-controller.yaml', 'w') as f:
+            f.write(service_data)
+            
+        cmd = ['kubectl', 'apply', '-f', './alb-ingress-controller.yaml']
+        logging.info("Run : %s" % json.dumps(cmd))
+        try:
+            out, err = run_with_timeout(cmd, env=env, timeout=100)
+            command_outputs.append((cmd, 0, out, err))
+        except KubeCommandException as e:
+            command_outputs.append((cmd, e.rv, e.out, e.err))
+
+        set_cluster_generic_property(dss_cluster_settings, 'alb-ingress.controller', 'true', True)
+
+        return make_html(command_outputs)

--- a/python-runnables/install-alb-controller/runnable.py
+++ b/python-runnables/install-alb-controller/runnable.py
@@ -93,6 +93,8 @@ class InstallAlb(Runnable):
                 policy_arn = policy.get('Arn', None)
 
         if policy_arn is None:
+            if not self.config("createPolicy", False):
+                raise Exception("Policy %s doesn't exist and the macro isn't allowed to create it" % policy_name)
             # create the policy
             args = ['iam', 'create-policy']
             args = args + ['--policy-name', policy_name]

--- a/python-runnables/remove-alb-controller/runnable.json
+++ b/python-runnables/remove-alb-controller/runnable.json
@@ -1,0 +1,30 @@
+{
+     "meta": {
+         "label": "Remove ALB controller",
+
+         "description": "Remove the controller on the cluster that creates ingresses using ALB.",
+
+         "icon": "icon-trash"
+     },
+    
+     "longDescription": "Policies that might have been added by the create ALB controller macro are not cleaned up",
+
+     "impersonate": false,
+
+     "macroRoles": [
+         { "type":"CLUSTER", "targetParamsKey":"clusterId", "limitToSamePlugin":true }
+     ],
+
+     "params": [
+     ],
+
+     "permissions": [],
+
+     "resultType": "HTML",
+
+     "resultLabel": "Removal output",
+
+     "extension": "txt",
+
+     "mimeType": "text/plain"
+ }

--- a/python-runnables/remove-alb-controller/runnable.py
+++ b/python-runnables/remove-alb-controller/runnable.py
@@ -1,0 +1,101 @@
+from dataiku.runnables import Runnable
+import dataiku
+import json, logging, os, re, tempfile, time
+import requests 
+from dku_aws.eksctl_command import EksctlCommand
+from dku_aws.aws_command import AwsCommand
+from dku_utils.cluster import get_cluster_from_dss_cluster, get_cluster_generic_property, set_cluster_generic_property
+from dku_utils.access import _has_not_blank_property
+from dku_kube.kubectl_command import run_with_timeout, KubeCommandException
+from dku_utils.access import _has_not_blank_property, _is_none_or_blank
+
+def make_html(command_outputs):
+    divs = []
+    for command_output in command_outputs:
+        cmd_html = '<div>Run: %s</div>' % json.dumps(command_output[0])
+        rv_html = '<div>Returned %s</div>' % command_output[1]
+        out_html = '<div class="alert alert-info"><div>Output</div><pre class="debug" style="max-width: 100%%; max-height: 100%%;">%s</pre></div>' % command_output[2]
+        err_html = '<div class="alert alert-danger"><div>Error</div><pre class="debug" style="max-width: 100%%; max-height: 100%%;">%s</pre></div>' % command_output[3]
+        divs.append(cmd_html)
+        divs.append(rv_html)
+        divs.append(out_html)
+        if command_output[1] != 0 and not _is_none_or_blank(command_output[3]):
+            divs.append(err_html)
+    return '\n'.join(divs).decode('utf8')
+
+class RemoveAlb(Runnable):
+    """
+    Installs a ALB ingress controller as described in https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html
+    """
+    def __init__(self, project_key, config, plugin_config):
+        self.project_key = project_key
+        self.config = config
+        self.plugin_config = plugin_config
+
+    def get_progress_target(self):
+        return None
+
+    def run(self, progress_callback):
+        cluster_data, dss_cluster_settings, dss_cluster_config = get_cluster_from_dss_cluster(self.config['clusterId'])
+
+        if get_cluster_generic_property(dss_cluster_settings, 'alb-ingress.controller', 'false') != 'true':
+            raise Exception("ALB controller not installed (or not by the installation macro)")
+
+        # retrieve the actual name in the cluster's data
+        if cluster_data is None:
+            raise Exception("No cluster data (not started?)")
+        cluster_def = cluster_data.get("cluster", None)
+        if cluster_def is None:
+            raise Exception("No cluster definition (starting failed?)")
+        cluster_id = cluster_def["Name"]
+        kube_config_path = dss_cluster_settings.get_raw()['containerSettings']['executionConfigsGenericOverrides']['kubeConfigPath']
+        connection_info = dss_cluster_config.get('config', {}).get('connectionInfo', {})
+        
+        env = os.environ.copy()
+        env['KUBECONFIG'] = kube_config_path
+
+        command_outputs = []
+        keep_going = True
+        
+        # delete the controller
+        cmd = ['kubectl', 'delete', '-f', 'https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.4/docs/examples/alb-ingress-controller.yaml']
+        logging.info("Run : %s" % json.dumps(cmd))
+        try:
+            out, err = run_with_timeout(cmd, env=env, timeout=100)
+            command_outputs.append((cmd, 0, out, err))
+        except KubeCommandException as e:
+            command_outputs.append((cmd, e.rv, e.out, e.err))
+            keep_going = False
+
+        if not keep_going:
+            return make_html(command_outputs)
+
+        # detach the role from the policy
+        args = ['delete', 'iamserviceaccount']
+        #args = args + ['-v', '4']
+        args = args + ['--name', 'alb-ingress-controller'] # that's the name in the rbac-role.yaml
+        args = args + ['--namespace', 'kube-system'] # that's the name in the rbac-role.yaml
+        args = args + ['--cluster', cluster_id]
+
+        if _has_not_blank_property(connection_info, 'region'):
+            args = args + ['--region', connection_info['region']]
+        elif 'AWS_DEFAULT_REGION' is os.environ:
+            args = args + ['--region', os.environ['AWS_DEFAULT_REGION']]
+
+        c = EksctlCommand(args, connection_info)
+        command_outputs.append(c.run())
+        if command_outputs[-1][1] != 0:
+            return make_html(command_outputs)
+        
+        # delete the role on the cluster
+        cmd = ['kubectl', 'delete', '-f', 'https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.4/docs/examples/rbac-role.yaml']
+        logging.info("Run : %s" % json.dumps(cmd))
+        try:
+            out, err = run_with_timeout(cmd, env=env, timeout=100)
+            command_outputs.append((cmd, 0, out, err))
+        except KubeCommandException as e:
+            command_outputs.append((cmd, e.rv, e.out, e.err))
+
+        set_cluster_generic_property(dss_cluster_settings, 'alb-ingress.controller', 'false', True)
+
+        return make_html(command_outputs)

--- a/python-runnables/run-on-kubectl/runnable.json
+++ b/python-runnables/run-on-kubectl/runnable.json
@@ -1,0 +1,53 @@
+{
+    "meta": {
+        "label": "Run Kubectl command",
+
+        "description": "Run a kubectl command on the cluster",
+
+        "icon": "icon-play"
+    },
+
+    "impersonate": false,
+
+    "macroRoles": [
+        { "type":"CLUSTER", "targetParamsKey":"clusterId", "limitToSamePlugin":true }
+    ],
+
+    "params": [
+        {
+            "name": "args",
+            "label": "Args",
+            "type": "STRINGS",
+            "description": "Kubectl command, like 'get pods'",
+            "mandatory": true
+        },
+        {
+            "name": "namespace",
+            "label": "Namespace",
+            "type": "STRING",
+            "mandatory": false
+        },
+        {
+            "name": "format",
+            "label": "Output format",
+            "type": "SELECT",
+            "mandatory": false,
+            "selectChoices": [
+                {"value":"none","label":"Default"},
+                {"value":"json","label":"JSON"},
+                {"value":"wide","label":"Wide"}
+            ],
+            "defaultValue":"none"
+        }
+    ],
+
+    "permissions": [],
+
+    "resultType": "HTML",
+
+    "resultLabel": "Command output",
+
+    "extension": "txt",
+
+    "mimeType": "text/plain"
+}

--- a/python-runnables/run-on-kubectl/runnable.py
+++ b/python-runnables/run-on-kubectl/runnable.py
@@ -1,0 +1,46 @@
+from dataiku.runnables import Runnable
+import dataiku
+import json, logging, os
+from dku_aws.eksctl_command import EksctlCommand
+from dku_aws.aws_command import AwsCommand
+from dku_utils.cluster import get_cluster_from_dss_cluster
+from dku_utils.access import _has_not_blank_property
+from dku_kube.kubectl_command import run_with_timeout, KubeCommandException
+from dku_utils.access import _has_not_blank_property, _is_none_or_blank
+
+class RunOnKubectl(Runnable):
+    def __init__(self, project_key, config, plugin_config):
+        self.project_key = project_key
+        self.config = config
+        self.plugin_config = plugin_config
+        
+    def get_progress_target(self):
+        return None
+
+    def run(self, progress_callback):
+        cluster_data, dss_cluster_settings, dss_cluster_config = get_cluster_from_dss_cluster(self.config['clusterId'])
+
+        kube_config_path = dss_cluster_settings.get_raw()['containerSettings']['executionConfigsGenericOverrides']['kubeConfigPath']
+
+        env = os.environ.copy()
+        env['KUBECONFIG'] = kube_config_path
+        cmd = ['kubectl'] + self.config.get('args', [])
+        if not _is_none_or_blank(self.config.get("namespace", "")):
+            cmd = cmd + ["--namespace", self.config.get("namespace", "")]
+        if not _is_none_or_blank(self.config.get("format", "")) and self.config.get("format", "") != 'none':
+            cmd = cmd + ["-o", self.config.get("format", "")]
+        logging.info("Run : %s" % json.dumps(cmd))
+        try:
+            out, err = run_with_timeout(cmd, env=env, timeout=20)
+            rv = 0
+        except KubeCommandException as e:
+            rv = e.rv
+            out = e.out
+            err = e.err
+            
+        out_html = '<div class="alert alert-info"><div>Output</div><pre class="debug" style="max-width: 100%%; max-height: 100%%;">%s</pre></div>' % out
+        err_html = '<div class="alert alert-danger"><div>Error</div><pre class="debug" style="max-width: 100%%; max-height: 100%%;">%s</pre></div>' % err
+        if rv == 0 or _is_none_or_blank(err):
+            return out_html
+        else:
+            return ('<div class="alert alert-danger">Failed with code %s</div>' % rv) + err_html + out_html        


### PR DESCRIPTION
[ch44703]

run the howto of https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html

notes on usage:
- put the `alb.ingress.kubernetes.io/scheme` -> `internet-facing` annotation on the ingress otherwise it's created internal
- you may need to kill -HUP the nginx pid to get it to work, because the ingress gives a hostname and it's usually not resolvable right away on the machine (so the nginx conf update with the brand new hostname fails)