### PR TITLE
Allow Private EKS Cluster Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ This plugin allows you to dynamically create, manage and scale EKS clusters in D
 
 Requires DSS 6.0 or above.
 
-For more details, please see https://doc.dataiku.com/dss/6.0/containers/eks
+For more details, please see https://doc.dataiku.com/dss/latest/containers/eks/

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -1,2 +1,3 @@
 PyYAML
 awscli
+boto3

--- a/parameter-sets/networking-settings/parameter-set.json
+++ b/parameter-sets/networking-settings/parameter-set.json
@@ -33,6 +33,14 @@
             "mandatory" : false
         },
         {
+            "name": "dssSecurityGroup",
+            "label": "DSS Security Group",
+            "description": "Provide Security Group ID of the DSS instance to update for private networking",
+            "visibilityCondition": "model.privateNetworking == true",
+            "type": "STRING",
+            "mandatory": false
+        },
+        {
             "name": "securityGroups",
             "label": "Security groups",
             "type": "STRINGS",

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -93,8 +93,6 @@ class MyCluster(Cluster):
 
         c = EksctlCommand(args, connection_info)
         cluster_info = json.loads(c.run_and_get_output())[0]
-        
-        logging.info(cluster_info)
 
         if networking_settings.get('privateNetworking', False):
             self.make_private(cluster_info['ResourcesVpcConfig']['SecurityGroupIds'][0])
@@ -181,7 +179,6 @@ class MyCluster(Cluster):
                             }
                         ]
                     )
-
         
         c = EksctlCommand(args, connection_info)
 

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -91,6 +91,9 @@ class MyCluster(Cluster):
 
         c = EksctlCommand(args, connection_info)
         cluster_info = json.loads(c.run_and_get_output())[0]
+
+        if networking_settings.get('privateNetworking', False):
+            self.make_private()
         
         with open(kube_config_path, "r") as f:
             kube_config = yaml.safe_load(f)
@@ -113,3 +116,11 @@ class MyCluster(Cluster):
 
         if c.run_and_log() != 0:
             raise Exception("Failed to stop cluster")
+
+    def make_private(self):
+        connection_info = self.config.get('connectionInfo', {})
+        args = ['utils', 'update-cluster-endpoints', '--cluster', self.cluster_id, '--private-access=true', '--public-access=false', '--approve']
+        
+        c = EksctlCommand(args, connection_info)
+        if c.run_and_log() != 0:
+            raise Exception("Failed to update to private cluster")

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -179,6 +179,7 @@ class MyCluster(Cluster):
                             }
                         ]
                     )
+                    return
         
         c = EksctlCommand(args, connection_info)
 

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -113,7 +113,7 @@ class MyCluster(Cluster):
         args = args + ['--name', self.cluster_id]
 
         if _has_not_blank_property(connection_info, 'region'):
-            region = connection_info['region'] 
+            region = connection_info['region']
         elif 'AWS_DEFAULT_REGION' is os.environ:
             region = os.environ['AWS_DEFAULT_REGION']
             


### PR DESCRIPTION
This PR modifies the EKS clusters plugin with the follow:

1. If private networking is enabled, update the cluster endpoint to go from public to private

2. After updating public to private, add security group entries (outbound from DSS SG on 443 to inbound on control plane SG on 443)

3. For stopping, we need the SG communication open until the cluster has a chance to begin terminating, so forked the PID and put sleep timer to wait adequate time before removing SG communication