### PR TITLE
Allow Advanced Configuration of EKS Clusters

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "eks-clusters",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "meta": {
         "label": "EKS clusters",
         "description": "Interact with Amazon Elastic Kubernetes Service clusters",

--- a/python-clusters/create-eks-cluster/cluster.json
+++ b/python-clusters/create-eks-cluster/cluster.json
@@ -59,7 +59,8 @@
         },
         {
             "name": "advancedYaml",
-            "label": "Advanced Configuration, use YAML",
+            "label": "Advanced Configuration",
+            "description": "Use YAML. For examples, see https://github.com/weaveworks/eksctl/tree/master/examples",
             "type": "TEXTAREA",
             "mandatory" : false,
             "visibilityCondition": "model.advanced == true"

--- a/python-clusters/create-eks-cluster/cluster.json
+++ b/python-clusters/create-eks-cluster/cluster.json
@@ -58,6 +58,12 @@
             "type": "BOOLEAN"
         },
         {
+            "name": "clusterAutoScaling",
+            "label": "Use Cluster Autoscaling",
+            "type": "BOOLEAN",
+            "visibilityCondition": "model.advanced == true"
+        },
+        {
             "name": "advancedYaml",
             "label": "Advanced Configuration",
             "description": "Use YAML. If you use advanced configuration, presets will not be used. For examples, see https://github.com/weaveworks/eksctl/tree/master/examples",

--- a/python-clusters/create-eks-cluster/cluster.json
+++ b/python-clusters/create-eks-cluster/cluster.json
@@ -26,7 +26,7 @@
             "label": "Network settings",
             "type": "PRESET",
             "parameterSetId" : "networking-settings",
-            "mandatory" : true
+            "mandatory" : false
         },
         {
             "name": "s-nodes",
@@ -38,7 +38,7 @@
             "label": "Initial node pool",
             "type": "PRESET",
             "parameterSetId" : "node-pool-request",
-            "mandatory" : true
+            "mandatory" : false
         },
         {
             "name": "s-advanced",
@@ -51,6 +51,18 @@
             "type": "STRING",
             "mandatory" : false,
             "description" : "Leave empty for current default of eksctl"
+        },
+        {
+            "name": "advanced",
+            "label": "Use Advanced Configuration",
+            "type": "BOOLEAN"
+        },
+        {
+            "name": "advancedYaml",
+            "label": "Advanced Configuration, use YAML",
+            "type": "TEXTAREA",
+            "mandatory" : false,
+            "visibilityCondition": "model.advanced == true"
         }
     ]
 }

--- a/python-clusters/create-eks-cluster/cluster.json
+++ b/python-clusters/create-eks-cluster/cluster.json
@@ -60,7 +60,7 @@
         {
             "name": "advancedYaml",
             "label": "Advanced Configuration",
-            "description": "Use YAML. For examples, see https://github.com/weaveworks/eksctl/tree/master/examples",
+            "description": "Use YAML. If you use advanced configuration, presets will not be used. For examples, see https://github.com/weaveworks/eksctl/tree/master/examples",
             "type": "TEXTAREA",
             "mandatory" : false,
             "visibilityCondition": "model.advanced == true"

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -21,7 +21,7 @@ class MyCluster(Cluster):
         networking_settings = self.config["networkingSettings"]
         
         args = ['create', 'cluster']
-        args = args + ['-v', '5']
+        args = args + ['-v', '4']
 
         if not self.config.get('advanced'):
             args = args + ['--name', self.cluster_id]

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -22,51 +22,60 @@ class MyCluster(Cluster):
         
         args = ['create', 'cluster']
         args = args + ['-v', '4']
-        args = args + ['--name', self.cluster_id]
-        
-        if _has_not_blank_property(connection_info, 'region'):
-            args = args + ['--region', connection_info['region']]
-        elif 'AWS_DEFAULT_REGION' is os.environ:
-            args = args + ['--region', os.environ['AWS_DEFAULT_REGION']]
+
+        if not self.config.get('advanced'):
+            args = args + ['--name', self.cluster_id]
             
-        args = args + ['--full-ecr-access']
-            
-        subnets = networking_settings.get('subnets', [])
-        if networking_settings.get('privateNetworking', False):
-            args = args + ['--node-private-networking']
-            private_subnets = networking_settings.get('privateSubnets', [])
-            if len(private_subnets) > 0:
-                args = args + ['--vpc-private-subnets', ','.join(private_subnets)]
-        if len(subnets) > 0:
-            args = args + ['--vpc-public-subnets', ','.join(subnets)]
-            
-        security_groups = networking_settings.get('securityGroups', [])
-        if len(security_groups) > 0:
-            args = args + ['--node-security-groups', ','.join(security_groups)]
-            
-            
-        node_pool = self.config.get('nodePool', {})
-        if 'machineType' in node_pool:
-            args = args + ['--node-type', node_pool['machineType']]
-        if 'diskType' in node_pool:
-            args = args + ['--node-volume-type', node_pool['diskType']]
-        if 'diskSizeGb' in node_pool and node_pool['diskSizeGb'] > 0:
-            args = args + ['--node-volume-size', str(node_pool['diskSizeGb'])]
-            
-        args = args + ['--nodes', str(node_pool.get('numNodes', 3))]
-        if node_pool.get('numNodesAutoscaling', False):
-            args = args + ['--asg-access']
-            args = args + ['--nodes-min', str(node_pool.get('minNumNodes', 2))]
-            args = args + ['--nodes-max', str(node_pool.get('maxNumNodes', 5))]
+            if _has_not_blank_property(connection_info, 'region'):
+                args = args + ['--region', connection_info['region']]
+            elif 'AWS_DEFAULT_REGION' is os.environ:
+                args = args + ['--region', os.environ['AWS_DEFAULT_REGION']]
+                
+            args = args + ['--full-ecr-access']
+                
+            subnets = networking_settings.get('subnets', [])
+            if networking_settings.get('privateNetworking', False):
+                args = args + ['--node-private-networking']
+                private_subnets = networking_settings.get('privateSubnets', [])
+                if len(private_subnets) > 0:
+                    args = args + ['--vpc-private-subnets', ','.join(private_subnets)]
+            if len(subnets) > 0:
+                args = args + ['--vpc-public-subnets', ','.join(subnets)]
+                
+            security_groups = networking_settings.get('securityGroups', [])
+            if len(security_groups) > 0:
+                args = args + ['--node-security-groups', ','.join(security_groups)]
+                
+                
+            node_pool = self.config.get('nodePool', {})
+            if 'machineType' in node_pool:
+                args = args + ['--node-type', node_pool['machineType']]
+            if 'diskType' in node_pool:
+                args = args + ['--node-volume-type', node_pool['diskType']]
+            if 'diskSizeGb' in node_pool and node_pool['diskSizeGb'] > 0:
+                args = args + ['--node-volume-size', str(node_pool['diskSizeGb'])]
+                
+            args = args + ['--nodes', str(node_pool.get('numNodes', 3))]
+            if node_pool.get('numNodesAutoscaling', False):
+                args = args + ['--asg-access']
+                args = args + ['--nodes-min', str(node_pool.get('minNumNodes', 2))]
+                args = args + ['--nodes-max', str(node_pool.get('maxNumNodes', 5))]
+
+            k8s_version = self.config.get("k8sVersion", None)
+            if not _is_none_or_blank(k8s_version):
+                args = args + ['--version', k8s_version.strip()]
+        else:
+            yaml_dict = yaml.safe_load(self.config.get("advancedYaml"))
+            yaml_loc = os.path.join(os.getcwd(), self.cluster_id +'_advanced.yaml')
+            with open(yaml_loc, 'w') as outfile:
+                yaml.dump(yaml_dict, outfile, default_flow_style=False)
+
+            args = args + ['-f', yaml_loc]
 
         # we don't add the context to the main config file, to not end up with an oversized config,
         # and because 2 different clusters could be concurrently editing the config file
         kube_config_path = os.path.join(os.getcwd(), 'kube_config')
         args = args + ['--kubeconfig', kube_config_path]
-        
-        k8s_version = self.config.get("k8sVersion", None)
-        if not _is_none_or_blank(k8s_version):
-            args = args + ['--version', k8s_version.strip()]
 
         c = EksctlCommand(args, connection_info)
         if c.run_and_log() != 0:
@@ -85,7 +94,11 @@ class MyCluster(Cluster):
             creds_in_env = {'AWS_ACCESS_KEY_ID':connection_info['accessKey'], 'AWS_SECRET_ACCESS_KEY':connection_info['secretKey']}
             add_authenticator_env(kube_config_path, creds_in_env)
         
-        if node_pool.get('numNodesAutoscaling', False):
+        if not self.config.get('advanced'):
+            if node_pool.get('numNodesAutoscaling', False):
+                logging.info("Nodegroup is autoscaling, ensuring autoscaler")
+                add_autoscaler_if_needed(self.cluster_id, kube_config_path)
+        else:
             logging.info("Nodegroup is autoscaling, ensuring autoscaler")
             add_autoscaler_if_needed(self.cluster_id, kube_config_path)
 

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -21,7 +21,7 @@ class MyCluster(Cluster):
         networking_settings = self.config["networkingSettings"]
         
         args = ['create', 'cluster']
-        args = args + ['-v', '4']
+        args = args + ['-v', '5']
 
         if not self.config.get('advanced'):
             args = args + ['--name', self.cluster_id]

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -98,7 +98,7 @@ class MyCluster(Cluster):
             if node_pool.get('numNodesAutoscaling', False):
                 logging.info("Nodegroup is autoscaling, ensuring autoscaler")
                 add_autoscaler_if_needed(self.cluster_id, kube_config_path)
-        else:
+        elif self.config.get('clusterAutoScaling'):
             logging.info("Nodegroup is autoscaling, ensuring autoscaler")
             add_autoscaler_if_needed(self.cluster_id, kube_config_path)
 


### PR DESCRIPTION
The purpose of this PR is to allow more advanced configurations of EKS clusters, similar to how it is implemented in GKE.

The difference here is that if the YAML option is used, configurations in the different presets will not be used. This is because eksctl either uses command line arguments to spin up clusters or a configuration file but not both. The presets are currently written to populate command line arguments, aside from the connection info preset.

This addition here opens up the ability for all of these different kinds of configurations from eksctl: https://github.com/weaveworks/eksctl/tree/master/examples

This work is an extension of the private cluster aspect of EKS. This does NOT solve the nodes reaching out over the public internet to connect to EKS but helps with handling all the security groups and any advanced configuration required for EKS cluster. The configuration file is way more feature rich than the command line options.