### PR TITLE
additional SG for workers whencreating new NG

### DIFF
--- a/parameter-sets/node-pool-request/parameter-set.json
+++ b/parameter-sets/node-pool-request/parameter-set.json
@@ -20,6 +20,14 @@
             "mandatory" : false
         },
         {
+            "name": "securityGroup",
+            "label": "security group",
+            "description": "additional security group for EKS workers",
+            "type": "STRING",
+            "defaultValue": "",
+            "mandatory" : false
+        },
+        {
             "name": "numNodes",
             "label": "Default number of nodes",
             "type": "INT",

--- a/python-runnables/add-node-pool/runnable.py
+++ b/python-runnables/add-node-pool/runnable.py
@@ -59,6 +59,8 @@ class MyRunnable(Runnable):
         node_pool = self.config.get('nodePool', {})
         if 'machineType' in node_pool:
             args = args + ['--node-type', node_pool['machineType']]
+         if 'securityGroup' in node_pool:
+            args = args + ['--node-security-groups', node_pool['securityGroup']]
         if 'diskType' in node_pool:
             args = args + ['--node-volume-type', node_pool['diskType']]
         if 'diskSizeGb' in node_pool and node_pool['diskSizeGb'] > 0:


### PR DESCRIPTION
If DSS instances are deployed in the same VPC as the EKS cluster
A pre-configured security group with full connectivity can be shared by DSS and workers
At nodegroup creation, this SG needs to be added to the eksctl command. 
This is option is already available in the cluster creation settings, but it was missing in the "add nodegroup"