### PR TITLE
The connectivity test macro in K8s plugin shouldn't try to resolve ip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PLUGIN_VERSION=1.0.1
+PLUGIN_VERSION=1.0.2
 PLUGIN_ID=eks-clusters
 
 plugin:

--- a/README.md
+++ b/README.md
@@ -5,3 +5,8 @@ This plugin allows you to dynamically create, manage and scale EKS clusters in D
 Requires DSS 6.0 or above.
 
 For more details, please see https://doc.dataiku.com/dss/latest/containers/eks
+
+## Release notes
+
+### v1.0.2
+- Fix `Test network connectivity` macro when the hostname is already an IP.

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -1,2 +1,3 @@
 PyYAML
 awscli
+ipaddress==1.0.23

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "eks-clusters",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "meta": {
         "label": "EKS clusters",
         "description": "Interact with Amazon Elastic Kubernetes Service clusters",

--- a/python-runnables/test-network/runnable.py
+++ b/python-runnables/test-network/runnable.py
@@ -50,7 +50,7 @@ class MyRunnable(Runnable):
                     ip = None
                     cmd = ['nslookup', host]
                     out, err = b.exec_cmd(cmd)
-                    result = add_to_result(result, 'Resolve host', cmd, out, err)
+                    result =  result + '<h5>Resolve host</h5><div style="margin-left: 20px;"><div>Command</div><pre class="debug">%s</pre><div>Output</div><pre class="debug">%s</pre><div>Error</div><pre class="debug">%s</pre></div>' % (json.dumps(cmd), out, err)
                     for line in out.split('\n'):
                         m = re.match('^Address.*\\s([0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+[^\\s]*)\\s.*$', line)
                         if m is not None:
@@ -63,7 +63,7 @@ class MyRunnable(Runnable):
                 # try to connect on the backend port
                 cmd = ['nc', '-vz', ip, port, '-w', '5']
                 out, err = b.exec_cmd(cmd, timeout=10)
-                result = add_to_result(result, 'Test connection to port', cmd, out, err)
+                result =  result + '<h5>Test connection to port</h5><div style="margin-left: 20px;"><div>Command</div><pre class="debug">%s</pre><div>Debug (stderr)</div><pre class="debug">%s</pre></div>' % (json.dumps(cmd), err)
                 if 'no route to host' in err.lower():
                     raise Exception("DSS node resolved but unreachable on port %s : %s" % (str(port), err))
 

--- a/python-runnables/test-network/runnable.py
+++ b/python-runnables/test-network/runnable.py
@@ -1,8 +1,8 @@
 from dataiku.runnables import Runnable
-import os, sys, json, yaml, random, subprocess, socket, re, traceback
+import os, sys, json, yaml, random, subprocess, socket, re, traceback, ipaddress
 from dku_kube.busybox_pod import BusyboxPod
-from dku_utils.cluster import get_cluster_from_dss_cluster
 from dku_kube.kubectl_command import KubeCommandException
+from dku_utils.cluster import get_cluster_from_dss_cluster
 
 class MyRunnable(Runnable):
 
@@ -15,7 +15,7 @@ class MyRunnable(Runnable):
         return None
 
     def run(self, progress_callback):
-        cluster_data, dss_cluster_settings, dss_cluster_config = get_cluster_from_dss_cluster(self.config['clusterId'])
+        cluster_data, _, dss_cluster_settings, _ = get_cluster_from_dss_cluster(self.config['clusterId'])
 
         # the cluster is accessible via the kubeconfig
         kube_config_path = dss_cluster_settings.get_raw()['containerSettings']['executionConfigsGenericOverrides']['kubeConfigPath']
@@ -26,7 +26,6 @@ class MyRunnable(Runnable):
         cluster_def = cluster_data.get("cluster", None)
         if cluster_def is None:
             raise Exception("No cluster definition (starting failed?)")
-        cluster_name = cluster_def["Name"]
         
         result = ''
         
@@ -42,19 +41,24 @@ class MyRunnable(Runnable):
             if host.startswith("127.0.0") or 'localhost' in host:
                 raise Exception('Host appears to not be a public hostname. Set DKU_BACKEND_EXT_HOST')
             with BusyboxPod(kube_config_path) as b:
-                # check that the pod resolved the hostname
-                ip = None
-                cmd = ['nslookup', host]
-                out, err = b.exec_cmd(cmd)
-                result = add_to_result(result, 'Resolve host', cmd, out, err)
-                for line in out.split('\n'):
-                    m = re.match('^Address.*\\s([0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+[^\\s]*)\\s.*$', line)
-                    if m is not None:
-                        ip = m.group(1)
-                if ip is None:
-                    raise Exception('Hostname resolution of DSS node failed: %s' % out)
+                try:
+                    ip = str(ipaddress.ip_address(unicode(host)))
+                    result = result + '<h5>Host %s is an ip. No need to resolve it, testing connection directly</h5>' % (host)
+
+                except ValueError:
+                    # check that the pod resolved the hostname
+                    ip = None
+                    cmd = ['nslookup', host]
+                    out, err = b.exec_cmd(cmd)
+                    result = add_to_result(result, 'Resolve host', cmd, out, err)
+                    for line in out.split('\n'):
+                        m = re.match('^Address.*\\s([0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+[^\\s]*)\\s.*$', line)
+                        if m is not None:
+                            ip = m.group(1)
+                    if ip is None:
+                        raise Exception('Hostname resolution of DSS node failed: %s' % out)
                     
-                result = result + '<h5>Host %s resolved to %s</h5>' % (host, ip)
+                    result = result + '<h5>Host %s resolved to %s</h5>' % (host, ip)
 
                 # try to connect on the backend port
                 cmd = ['nc', '-vz', ip, port, '-w', '5']
@@ -73,4 +77,3 @@ class MyRunnable(Runnable):
             result = result + '<div class="alert alert-error">%s</div>' % str(e)
                 
         return '<div>%s</div>' % result
-            


### PR DESCRIPTION
[ch47077]
The connectivity test macro try to resolve hostname before checking connectivity.
When the "host" is already an IP this messes up the check.