### PR TITLE
Correct eksctl download url to new location

### DIFF
--- a/python-lib/dku_aws/eksctl_loader.py
+++ b/python-lib/dku_aws/eksctl_loader.py
@@ -14,7 +14,7 @@ def get_eksctl_or_fetch():
         if not os.path.exists(local_eksctl):
             arch = subprocess.check_output(["uname", "-s"]).strip()
             logging.info("Downloading eksctl for %s" % arch)
-            r = requests.get("https://github.com/weaveworks/eksctl/releases/download/latest_release/eksctl_%s_amd64.tar.gz" % arch, stream=True)
+            r = requests.get("https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_%s_amd64.tar.gz" % arch, stream=True)
             local_eksctl_archive = os.path.join(local_eksctl_folder, 'eksctl.tar.gz')
             with open(local_eksctl_archive, 'wb') as f:
                 shutil.copyfileobj(r.raw, f)


### PR DESCRIPTION
The path for downloading eksctl was updated, which results in the plugin making an empty file that it can't un-tar. This update   just corrects the URL to avoid that condition