### PR TITLE
[sc70246] added utility method to remove leading and trailing spaces …

### DIFF
--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -8,6 +8,7 @@ from dku_kube.autoscaler import add_autoscaler_if_needed
 from dku_kube.gpu_driver import add_gpu_driver_if_needed
 from dku_utils.cluster import make_overrides
 from dku_utils.access import _has_not_blank_property, _is_none_or_blank
+from dku_utils.config_parser import getSecurityGroupsArg
 
 class MyCluster(Cluster):
     def __init__(self, cluster_id, cluster_name, config, plugin_config, global_settings):
@@ -43,10 +44,7 @@ class MyCluster(Cluster):
             if len(subnets) > 0:
                 args = args + ['--vpc-public-subnets', ','.join(subnets)]
                 
-            security_groups = networking_settings.get('securityGroups', [])
-            if len(security_groups) > 0:
-                args = args + ['--node-security-groups', ','.join(security_groups)]
-                
+            args += getSecurityGroupsArg(networking_settings)
                 
             node_pool = self.config.get('nodePool', {})
             if 'machineType' in node_pool:

--- a/python-lib/dku_utils/config_parser.py
+++ b/python-lib/dku_utils/config_parser.py
@@ -1,0 +1,16 @@
+# Provide some utility methods to parse the saved configuration, clean it, normalize it and return in a predifined format (ex: command line args)
+
+SECURITY_GROUPS = 'securityGroups'
+SECURITY_GROUPS_ARG = '--node-security-groups'
+
+# retrieves the EKS Cluster SecurityGroups (network param), remove all leading and trailing
+# spaces and returns it as a eksctl command line argument
+def getSecurityGroupsArg(config):
+    if config is None or not isinstance(config, dict):
+        raise Exception("config can not be null and has to be a dictionnary.")
+    params = config.get(SECURITY_GROUPS, [])
+    if len(params) > 0:
+        params = list(map(str.strip, params))
+        params = list(filter(None, params))
+        return [SECURITY_GROUPS_ARG, ','.join(params)]
+    return []

--- a/python-runnables/add-node-pool/runnable.py
+++ b/python-runnables/add-node-pool/runnable.py
@@ -7,6 +7,7 @@ from dku_aws.eksctl_command import EksctlCommand
 from dku_aws.aws_command import AwsCommand
 from dku_utils.cluster import get_cluster_from_dss_cluster
 from dku_utils.access import _has_not_blank_property
+from dku_utils.config_parser import getSecurityGroupsArg
 
 class MyRunnable(Runnable):
     def __init__(self, project_key, config, plugin_config):
@@ -52,10 +53,7 @@ class MyRunnable(Runnable):
         if dss_cluster_config.get('privateNetworking', False) or self.config.get('privateNetworking', None):
             args = args + ['--node-private-networking']
             
-        security_groups = dss_cluster_config['config'].get('securityGroups', [])
-        if len(security_groups) > 0:
-            args = args + ['--node-security-groups', ','.join(security_groups)]
-            
+        args += getSecurityGroupsArg(dss_cluster_config['config'])
             
         node_pool = self.config.get('nodePool', {})
         if 'machineType' in node_pool:


### PR DESCRIPTION
[sc70246] just handled the case described in the shortcut ticket (remove leading an trailing spaces in Security Groups).
Didn't want to do a more in depth refactoring to better handle more config params to avoid introducing regressions in a deployed plugin. But maybe at some point, it could be done.