### PR TITLE
Bug/dss100 sc 70246 missing parameters trimming in eks cluster

### DIFF
--- a/python-lib/dku_utils/config_parser.py
+++ b/python-lib/dku_utils/config_parser.py
@@ -18,6 +18,6 @@ def get_security_groups_arg(config):
     if len(params) == 0:
         return []
 
-    params = list(map(str.strip, params))
+    params = list(map(lambda param: param.strip(), params))
     params = list(filter(None, params))
     return [SECURITY_GROUPS_ARG, ','.join(params)]


### PR DESCRIPTION
[SH-70246] modified syntax which was not supported by python 2.7