### PR TITLE
Fix URL to eksctl's documentation

### DIFF
--- a/parameter-sets/networking-settings/parameter-set.json
+++ b/parameter-sets/networking-settings/parameter-set.json
@@ -14,7 +14,7 @@
             "name": "subnets",
             "label": "VPC subnets",
             "type": "STRINGS",
-            "description": "Put at least 2 subnets. Check https://github.com/weaveworks/eksctl#use-existing-vpc-any-custom-configuration for constraints.",
+            "description": "Put at least 2 subnets. Check https://eksctl.io/usage/vpc-configuration/#use-existing-vpc-other-custom-configuration for constraints.",
             "mandatory" : false
         },
         {
@@ -29,7 +29,7 @@
             "label": "VPC private subnets",
             "visibilityCondition": "model.privateNetworking == true",
             "type": "STRINGS",
-            "description": "Put at least 2 subnets. Check https://github.com/weaveworks/eksctl#use-existing-vpc-any-custom-configuration for constraints.",
+            "description": "Put at least 2 subnets. Check https://eksctl.io/usage/vpc-configuration/#use-existing-vpc-other-custom-configuration for constraints.",
             "mandatory" : false
         },
         {


### PR DESCRIPTION
This is a very small PR fixing links to *eksctl*'s documentation that are displayed in the plugin configuration:

<img width="1387" alt="Capture d’écran 2022-01-17 à 15 30 51" src="https://user-images.githubusercontent.com/6297260/149788317-002b1b85-5845-4b3f-835c-dcab40dca0e5.png">

The previous link was [https://github.com/weaveworks/eksctl#use-existing-vpc-any-custom-configuration](https://github.com/weaveworks/eksctl#use-existing-vpc-any-custom-configuration) which doesn't point to any specific section in the README.

I replaced it with [https://eksctl.io/usage/vpc-configuration/#use-existing-vpc-other-custom-configuration](https://eksctl.io/usage/vpc-configuration/#use-existing-vpc-other-custom-configuration).