### PR TITLE
[SC-82914] deprecated macro `Run Kubectl command`which will be native…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Version 1.0.8 - Internal release
-- Deprecated macro `Run Kubectl command`(natively supported in DSS 10.0.6)
+- Deprecated macro `Run Kubectl command` (natively supported in DSS 10.0.6)
 
 ## Version 1.0.7 - Bugfix release
 - Add capability to assume IAM role on all cluster operation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Version 1.0.8 - Internal release
-- deprecated macro `Run Kubectl command` which will be natively supported in V10.0.6
+- Deprecated macro `Run Kubectl command`(natively supported in DSS 10.0.6)
 
 ## Version 1.0.7 - Bugfix release
 - Add capability to assume IAM role on all cluster operation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 1.0.8 - Internal release
+- deprecated macro `Run Kubectl command` which will be natively supported in V10.0.6
+
 ## Version 1.0.7 - Bugfix release
 - Add capability to assume IAM role on all cluster operation
 - Fix use of `AWS_DEFAULT_REGION` environment variable

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "eks-clusters",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "meta": {
         "label": "EKS clusters",
         "description": "Interact with Amazon Elastic Kubernetes Service clusters",

--- a/python-runnables/run-on-kubectl/runnable.json
+++ b/python-runnables/run-on-kubectl/runnable.json
@@ -2,7 +2,7 @@
     "meta": {
         "label": "Run Kubectl command",
 
-        "description": "Run a kubectl command on the cluster (deprecated: as of V10.0.6 that feature will be natively supported).",
+        "description": "Run a kubectl command on the cluster (deprecated: as of DSS 10.0.6 this feature is natively supported).",
 
         "icon": "icon-play"
     },

--- a/python-runnables/run-on-kubectl/runnable.json
+++ b/python-runnables/run-on-kubectl/runnable.json
@@ -2,7 +2,7 @@
     "meta": {
         "label": "Run Kubectl command",
 
-        "description": "Run a kubectl command on the cluster",
+        "description": "Run a kubectl command on the cluster (deprecated: as of V10.0.6 that feature will be natively supported).",
 
         "icon": "icon-play"
     },

--- a/python-runnables/run-on-kubectl/runnable.json
+++ b/python-runnables/run-on-kubectl/runnable.json
@@ -1,6 +1,6 @@
 {
     "meta": {
-        "label": "Run Kubectl command",
+        "label": "Run Kubectl command (deprecated)",
 
         "description": "Run a kubectl command on the cluster (deprecated: as of DSS 10.0.6 this feature is natively supported).",
 


### PR DESCRIPTION
[SC-82914] marking `Run Kubectl command` macro as deprecated (will be natively supported with V10.0.6)