### PR TITLE
Fix 'inspect node pools' macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Next version
+- Fix "Inspect node pools" macro when using managed node groups
+
 ## Version 1.0.7 - Bugfix release
 - Add capability to assume IAM role on all cluster operation
 - Fix use of `AWS_DEFAULT_REGION` environment variable


### PR DESCRIPTION
To create managed node groups, the easiest way is probably to make sure you are using a relatively recent version of `eksctl`. But, it would be good to test with both managed and unmanaged node groups, both "old" (like 0.51) and new versions of `eksctl`.

I removed the call to describe the stack resources since it was being used to get the auto scaling group name, but that name is already available in the output of the first `get nodegroup`. While reading the `eksctl` code, I noticed that they allow for managed node groups to have multiple autoscaling groups, but I'm not sure how that's possible, so I assumed there will always only be one auto scaling group name.

[sc-86393]