### PR TITLE
Feature/dss100 sc 85144 eks plugin eats error if eksctl fails and

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .htmlcov
 .DS_Store
 .idea
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Version 1.0.9 - Feature and bugfix release
+## NEXT VERSION
 - Throwing an exception when command invoked by `EksctlCommand.run_and_get_output` or `AwsCommand.run_and_get_output` fails
 
 ## Version 1.0.8 - Feature and bugfix release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 1.0.9 - Feature and bugfix release
+- Throwing an exception when command launched by `EksctlCommand.run_and_get_output` or `AwsCommand.run_and_get_output` fails
+
 ## Version 1.0.8 - Feature and bugfix release
 - Add option to install Metrics Server
 - Fix "Inspect node pools" macro when using managed node groups

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Version 1.0.9 - Feature and bugfix release
-- Throwing an exception when command launched by `EksctlCommand.run_and_get_output` or `AwsCommand.run_and_get_output` fails
+- Throwing an exception when command invoked by `EksctlCommand.run_and_get_output` or `AwsCommand.run_and_get_output` fails
 
 ## Version 1.0.8 - Feature and bugfix release
 - Add option to install Metrics Server

--- a/python-lib/dku_aws/aws_command.py
+++ b/python-lib/dku_aws/aws_command.py
@@ -13,7 +13,7 @@ class AwsCommand(object):
             self.env['AWS_SESSION_TOKEN'] = connection_info['sessionToken']
         if _has_not_blank_property(connection_info, 'region'):
             self.env['AWS_DEFAULT_REGION'] = connection_info['region']
-        
+
     def run(self):
         cmd = _convert_to_string(["aws"] + self.args)
         logging.info('Running %s' % (' '.join(cmd)))
@@ -28,8 +28,13 @@ class AwsCommand(object):
         return (cmd, rv, o, e)
 
     def run_and_get_output(self):
-        return self.run()[2]
-    
+        result = self.run()
+        if result[1] != 0:
+            cmd = _convert_to_string([self.eksctl_bin] + self.args)
+            raise Exception('Execution of command \'%s\' Failed. Returned error: %s' % (' '.join(cmd), result[3]))
+        else :
+            return result[2]
+
     def run_and_log(self):
         cmd = _convert_to_string(["aws"] + self.args)
         logging.info('Running %s' % (' '.join(cmd)))

--- a/python-lib/dku_aws/aws_command.py
+++ b/python-lib/dku_aws/aws_command.py
@@ -30,8 +30,9 @@ class AwsCommand(object):
     def run_and_get_output(self):
         result = self.run()
         if result[1] != 0:
+            logging.error(result[3])
             cmd = _convert_to_string(["aws"] + self.args)
-            raise Exception('Failed to execute command: \'%s\'.' % (' '.join(cmd)))
+            raise Exception('Failed to execute command: \'%s\'. See log for more details.' % (' '.join(cmd)))
         else:
             return result[2]
 

--- a/python-lib/dku_aws/aws_command.py
+++ b/python-lib/dku_aws/aws_command.py
@@ -32,7 +32,7 @@ class AwsCommand(object):
         if result[1] != 0:
             cmd = _convert_to_string([self.eksctl_bin] + self.args)
             raise Exception('Execution of command \'%s\' Failed. Returned error: %s' % (' '.join(cmd), result[3]))
-        else :
+        else:
             return result[2]
 
     def run_and_log(self):

--- a/python-lib/dku_aws/aws_command.py
+++ b/python-lib/dku_aws/aws_command.py
@@ -30,9 +30,9 @@ class AwsCommand(object):
     def run_and_get_output(self):
         result = self.run()
         if result[1] != 0:
+            logging.error(result[3])
             cmd = _convert_to_string(["aws"] + self.args)
-            logging.error('Failed to execute aws command:\n%s\n%s' % (' '.join(cmd), result[3]))
-            raise Exception('Failed to execute aws command. See log for more details.')
+            raise Exception('Failed to execute command: \'%s\'. See log for more details.' % (' '.join(cmd)))
         else:
             return result[2]
 

--- a/python-lib/dku_aws/aws_command.py
+++ b/python-lib/dku_aws/aws_command.py
@@ -30,9 +30,9 @@ class AwsCommand(object):
     def run_and_get_output(self):
         result = self.run()
         if result[1] != 0:
-            logging.error(result[3])
             cmd = _convert_to_string(["aws"] + self.args)
-            raise Exception('Failed to execute command: \'%s\'. See log for more details.' % (' '.join(cmd)))
+            logging.error('Failed to execute aws command:\n%s\nError:\n%s' % (' '.join(cmd), result[3]))
+            raise Exception('Failed to execute aws command. See log for more details.')
         else:
             return result[2]
 

--- a/python-lib/dku_aws/aws_command.py
+++ b/python-lib/dku_aws/aws_command.py
@@ -31,7 +31,7 @@ class AwsCommand(object):
         result = self.run()
         if result[1] != 0:
             cmd = _convert_to_string(["aws"] + self.args)
-            logging.error('Failed to execute aws command:\n%s\nError:\n%s' % (' '.join(cmd), result[3]))
+            logging.error('Failed to execute aws command:\n%s\n%s' % (' '.join(cmd), result[3]))
             raise Exception('Failed to execute aws command. See log for more details.')
         else:
             return result[2]

--- a/python-lib/dku_aws/aws_command.py
+++ b/python-lib/dku_aws/aws_command.py
@@ -30,8 +30,8 @@ class AwsCommand(object):
     def run_and_get_output(self):
         result = self.run()
         if result[1] != 0:
-            cmd = _convert_to_string([self.eksctl_bin] + self.args)
-            raise Exception('Execution of command \'%s\' Failed. Returned error: %s' % (' '.join(cmd), result[3]))
+            cmd = _convert_to_string(["aws"] + self.args)
+            raise Exception('Failed to execute command: \'%s\'.' % (' '.join(cmd)))
         else:
             return result[2]
 

--- a/python-lib/dku_aws/eksctl_command.py
+++ b/python-lib/dku_aws/eksctl_command.py
@@ -33,7 +33,7 @@ class EksctlCommand(object):
         result = self.run()
         if result[1] != 0:
             cmd = _convert_to_string([self.eksctl_bin] + self.args)
-            logging.error('Failed to execute eksctl command:\n%s\nError:\n%s' % (' '.join(cmd), result[3]))
+            logging.error('Failed to execute eksctl command:\n%s\n%s' % (' '.join(cmd), result[3]))
             raise Exception('Failed to execute eksctl command. See log for more details.')
         else:
             return result[2]

--- a/python-lib/dku_aws/eksctl_command.py
+++ b/python-lib/dku_aws/eksctl_command.py
@@ -34,7 +34,7 @@ class EksctlCommand(object):
         if result[1] != 0:
             cmd = _convert_to_string([self.eksctl_bin] + self.args)
             raise Exception('Execution of command \'%s\' Failed. Returned error: %s' % (' '.join(cmd), result[3]))
-        else :
+        else:
             return result[2]
 
     def run_and_log(self):

--- a/python-lib/dku_aws/eksctl_command.py
+++ b/python-lib/dku_aws/eksctl_command.py
@@ -32,8 +32,9 @@ class EksctlCommand(object):
     def run_and_get_output(self):
         result = self.run()
         if result[1] != 0:
+            logging.error(result[3])
             cmd = _convert_to_string([self.eksctl_bin] + self.args)
-            raise Exception('Failed to execute command: \'%s\'.' % (' '.join(cmd)))
+            raise Exception('Failed to execute command: \'%s\'. See log for more details.' % (' '.join(cmd)))
         else:
             return result[2]
 

--- a/python-lib/dku_aws/eksctl_command.py
+++ b/python-lib/dku_aws/eksctl_command.py
@@ -32,9 +32,9 @@ class EksctlCommand(object):
     def run_and_get_output(self):
         result = self.run()
         if result[1] != 0:
-            logging.error(result[3])
             cmd = _convert_to_string([self.eksctl_bin] + self.args)
-            raise Exception('Failed to execute command: \'%s\'. See log for more details.' % (' '.join(cmd)))
+            logging.error('Failed to execute eksctl command:\n%s\nError:\n%s' % (' '.join(cmd), result[3]))
+            raise Exception('Failed to execute eksctl command. See log for more details.')
         else:
             return result[2]
 

--- a/python-lib/dku_aws/eksctl_command.py
+++ b/python-lib/dku_aws/eksctl_command.py
@@ -15,7 +15,7 @@ class EksctlCommand(object):
             self.env['AWS_SESSION_TOKEN'] = connection_info['sessionToken']
         if _has_not_blank_property(connection_info, 'region'):
             self.env['AWS_DEFAULT_REGION'] = connection_info['region']
-        
+
     def run(self):
         cmd = _convert_to_string([self.eksctl_bin] + self.args)
         logging.info('Running %s' % (' '.join(cmd)))
@@ -30,8 +30,13 @@ class EksctlCommand(object):
         return (cmd, rv, o, e)
 
     def run_and_get_output(self):
-        return self.run()[2]
-    
+        result = self.run()
+        if result[1] != 0:
+            cmd = _convert_to_string([self.eksctl_bin] + self.args)
+            raise Exception('Execution of command \'%s\' Failed. Returned error: %s' % (' '.join(cmd), result[3]))
+        else :
+            return result[2]
+
     def run_and_log(self):
         cmd = _convert_to_string([self.eksctl_bin] + self.args)
         logging.info('Running %s' % (' '.join(cmd)))
@@ -45,7 +50,7 @@ class EksctlCommand(object):
             for line in iter(s.readline, ''):
                 logging.info(line.rstrip())
         return p.wait()
-    
+
     def run_and_get(self):
         cmd = _convert_to_string([self.eksctl_bin] + self.args)
         logging.info('Running %s' % (' '.join(cmd)))

--- a/python-lib/dku_aws/eksctl_command.py
+++ b/python-lib/dku_aws/eksctl_command.py
@@ -32,9 +32,9 @@ class EksctlCommand(object):
     def run_and_get_output(self):
         result = self.run()
         if result[1] != 0:
+            logging.error(result[3])
             cmd = _convert_to_string([self.eksctl_bin] + self.args)
-            logging.error('Failed to execute eksctl command:\n%s\n%s' % (' '.join(cmd), result[3]))
-            raise Exception('Failed to execute eksctl command. See log for more details.')
+            raise Exception('Failed to execute command: \'%s\'. See log for more details.' % (' '.join(cmd)))
         else:
             return result[2]
 

--- a/python-lib/dku_aws/eksctl_command.py
+++ b/python-lib/dku_aws/eksctl_command.py
@@ -33,7 +33,7 @@ class EksctlCommand(object):
         result = self.run()
         if result[1] != 0:
             cmd = _convert_to_string([self.eksctl_bin] + self.args)
-            raise Exception('Execution of command \'%s\' Failed. Returned error: %s' % (' '.join(cmd), result[3]))
+            raise Exception('Failed to execute command: \'%s\'.' % (' '.join(cmd)))
         else:
             return result[2]
 


### PR DESCRIPTION
[SC-85144] throwing an exception when command invoked by `EksctlCommand.run_and_get_output` or `AwsCommand.run_and_get_output` fails.

The error output is not appended to the exception message. It can be very long and can not be formatted (the exception is caught by the plugin execution framework and rethrown within another message).