### PR TITLE
add option for fully-private cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## NEXT VERSION
 - Throwing an exception when command invoked by `EksctlCommand.run_and_get_output` or `AwsCommand.run_and_get_output` fails
+- Handle creating fully-private clusters (nodes in private subnets and private control plane endpoint)
 
 ## Version 1.0.8 - Feature and bugfix release
 - Add option to install Metrics Server

--- a/parameter-sets/networking-settings/parameter-set.json
+++ b/parameter-sets/networking-settings/parameter-set.json
@@ -43,13 +43,13 @@
             "name": "controlPlaneSG",
             "label": "Control plane SG",
             "type": "STRING",
-            "description": "Optional: security group to use for the control plane"
+            "description": "Optional: Control Plane will be put in this SG. Must allow inbound from DSS if you don't use Shared SG"
         },
         {
             "name": "sharedSG",
             "label": "Shared SG",
             "type": "STRING",
-            "description": "Optional: security group to use for control plane, nodes and VPC endpoints (in private cluse-ters)"
+            "description": "Optional: Control Plane, Nodes and VPC endpoints will be put in this SG. Should be allow inbound from DSS"
         }
     ]
 }

--- a/parameter-sets/networking-settings/parameter-set.json
+++ b/parameter-sets/networking-settings/parameter-set.json
@@ -38,6 +38,18 @@
             "type": "STRINGS",
             "description": "Additional security groups for the nodes. Needed to give access to the node running DSS",
             "mandatory" : false
+        },
+        {
+            "name": "controlPlaneSG",
+            "label": "Control plane SG",
+            "type": "STRING",
+            "description": "Optional: security group to use for the control plane"
+        },
+        {
+            "name": "sharedSG",
+            "label": "Shared SG",
+            "type": "STRING",
+            "description": "Optional: security group to use for control plane, nodes and VPC endpoints (in private cluse-ters)"
         }
     ]
 }

--- a/parameter-sets/node-pool-request/parameter-set.json
+++ b/parameter-sets/node-pool-request/parameter-set.json
@@ -84,6 +84,13 @@
             "defaultValue": false
         },
         {
+            "name": "preBootstrapCommands",
+            "label": "Pre-bootstrap commands",
+            "description": "Executed before bootstrapping instances to the cluster",
+            "type": "TEXTAREA",
+            "codeMirrorDialect": "text/x-sh"
+        },
+        {
             "name": "tags",
             "label": "Tags",
             "description": "Tags to apply on the created EC2 instances",

--- a/parameter-sets/node-pool-request/parameter-set.json
+++ b/parameter-sets/node-pool-request/parameter-set.json
@@ -77,6 +77,12 @@
             "mandatory" : false
         },
         {
+            "name": "publicKeyName",
+            "label": "Keypair name",
+            "description": "Name of a keypair to use on the instances of the node group",
+            "type": "STRING"
+        },
+        {
             "name": "enableGPU",
             "label": "GPU",
             "description": "Enable GPU workloads on the cluster",

--- a/parameter-sets/node-pool-request/parameter-set.json
+++ b/parameter-sets/node-pool-request/parameter-set.json
@@ -84,11 +84,17 @@
             "defaultValue": false
         },
         {
+            "name": "addPreBootstrapCommands",
+            "label": "Add pre-bootstrap commands",
+            "type": "BOOLEAN"
+        },
+        {
             "name": "preBootstrapCommands",
             "label": "Pre-bootstrap commands",
             "description": "Executed before bootstrapping instances to the cluster",
             "type": "TEXTAREA",
-            "codeMirrorDialect": "text/x-sh"
+            "codeMirrorDialect": "text/x-sh",
+            "visibilityCondition": "model.addPreBootstrapCommands == true"
         },
         {
             "name": "tags",

--- a/python-clusters/create-eks-cluster/cluster.json
+++ b/python-clusters/create-eks-cluster/cluster.json
@@ -83,14 +83,14 @@
             "name": "controlPlaneSG",
             "label": "Control plane SG",
             "type": "STRING",
-            "description": "Security group to use for the control plane. Should allow access from the DSS VM.",
+            "description": "Security group to use for the control plane. Can be used to allow access from the DSS VM.",
             "visibilityCondition": "model.privateCluster == true"
         },
         {
             "name": "sharedSG",
             "label": "Shared SG",
             "type": "STRING",
-            "description": "Security group to use for control plane and VPC endpoints. Should allow access from the DSS VM.",
+            "description": "Security group to use for control plane and VPC endpoints. Can be used to allow access from the DSS VM.",
             "visibilityCondition": "model.privateCluster == true"
         },
         {
@@ -98,6 +98,12 @@
             "label": "Injected DSS SG",
             "type": "STRING",
             "description": "Security group to add as inbound on the cluster's autocreated SGs. Should allow access from the DSS VM."
+        },
+        {
+            "name": "makePrivateOnly",
+            "label": "Revoke public access",
+            "type": "BOOLEAN",
+            "description": "If true, the EKS endpoint is made private-only"
         },
         {
             "name": "advanced",

--- a/python-clusters/create-eks-cluster/cluster.json
+++ b/python-clusters/create-eks-cluster/cluster.json
@@ -67,6 +67,25 @@
              "defaultValue" : true
         },
         {
+            "name": "privateCluster",
+            "label": "Fully-private",
+            "type": "BOOLEAN",
+            "description": "VPC endpoints will be created for the cluster. The first security group of the Network Settings will be used as shared SG."
+        },
+        {
+            "name": "skipEndpointCreation",
+            "label": "Skip VPC Endpoints creation",
+            "type": "BOOLEAN",
+            "description": "If the VPC endpoints already exist, don't attempt to create new ones"
+        },
+        {
+            "name": "sharedSG",
+            "label": "Shared Security Group",
+            "type": "STRING",
+            "description": "Security group to used for the control plane. Should allow access from the DSS VM.",
+            "visibilityCondition": "model.privateCluster == true"
+        },
+        {
             "name": "advanced",
             "label": "Use Advanced Configuration",
             "type": "BOOLEAN"

--- a/python-clusters/create-eks-cluster/cluster.json
+++ b/python-clusters/create-eks-cluster/cluster.json
@@ -80,11 +80,24 @@
             "visibilityCondition": "model.privateCluster == true"
         },
         {
-            "name": "sharedSG",
-            "label": "Shared Security Group",
+            "name": "controlPlaneSG",
+            "label": "Control plane SG",
             "type": "STRING",
-            "description": "Security group to used for the control plane. Should allow access from the DSS VM.",
+            "description": "Security group to use for the control plane. Should allow access from the DSS VM.",
             "visibilityCondition": "model.privateCluster == true"
+        },
+        {
+            "name": "sharedSG",
+            "label": "Shared SG",
+            "type": "STRING",
+            "description": "Security group to use for control plane and VPC endpoints. Should allow access from the DSS VM.",
+            "visibilityCondition": "model.privateCluster == true"
+        },
+        {
+            "name": "injectedSG",
+            "label": "Injected DSS SG",
+            "type": "STRING",
+            "description": "Security group to add as inbound on the cluster's autocreated SGs. Should allow access from the DSS VM."
         },
         {
             "name": "advanced",

--- a/python-clusters/create-eks-cluster/cluster.json
+++ b/python-clusters/create-eks-cluster/cluster.json
@@ -80,20 +80,6 @@
             "visibilityCondition": "model.privateCluster == true"
         },
         {
-            "name": "controlPlaneSG",
-            "label": "Control plane SG",
-            "type": "STRING",
-            "description": "Security group to use for the control plane. Can be used to allow access from the DSS VM.",
-            "visibilityCondition": "model.privateCluster == true"
-        },
-        {
-            "name": "sharedSG",
-            "label": "Shared SG",
-            "type": "STRING",
-            "description": "Security group to use for control plane and VPC endpoints. Can be used to allow access from the DSS VM.",
-            "visibilityCondition": "model.privateCluster == true"
-        },
-        {
             "name": "injectedSG",
             "label": "Injected DSS SG",
             "type": "STRING",

--- a/python-clusters/create-eks-cluster/cluster.json
+++ b/python-clusters/create-eks-cluster/cluster.json
@@ -76,7 +76,8 @@
             "name": "skipEndpointCreation",
             "label": "Skip VPC Endpoints creation",
             "type": "BOOLEAN",
-            "description": "If the VPC endpoints already exist, don't attempt to create new ones"
+            "description": "If the VPC endpoints already exist, don't attempt to create new ones",
+            "visibilityCondition": "model.privateCluster == true"
         },
         {
             "name": "sharedSG",

--- a/python-clusters/create-eks-cluster/cluster.json
+++ b/python-clusters/create-eks-cluster/cluster.json
@@ -83,7 +83,7 @@
             "name": "injectedSG",
             "label": "Injected DSS SG",
             "type": "STRING",
-            "description": "Security group to add as inbound on the cluster's autocreated SGs. Should allow access from the DSS VM."
+            "description": "Security group to add as inbound on the cluster's autocreated SGs. Should allow inbound from DSS."
         },
         {
             "name": "makePrivateOnly",

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -99,7 +99,7 @@ class MyCluster(Cluster):
                     raise Exception("A shared SG is needed to guarantee that the control plane will be accessible from the DSS VM")
                 yaml_dict['vpc']['sharedNodeSecurityGroup'] = security_group
                 
-            if not _is_none_or_blank(node_pool.get("preBootstrapCommands", "")):
+            if node_pool.get('addPreBootstrapCommands', False) and not _is_none_or_blank(node_pool.get("preBootstrapCommands", "")):
                 # has to be added in the yaml, there is no command line flag for that
                 commands = node_pool.get("preBootstrapCommands", "")
                 for node_pool_dict in yaml_dict['managedNodeGroups']:

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -209,6 +209,16 @@ class MyCluster(Cluster):
         if c.run_and_log() != 0:
             raise Exception("Failed to start cluster")
 
+        # if you leave eksctl work, you have a public/private EKS endpoint, so we can tighten it even more
+        if not self.config.get('makePrivateOnly', False):
+            privatize_args = ['utils', 'update-cluster-endpoints']
+            privatize_args = privatize_args + ['--name', self.cluster_id]
+            privatize_args = privatize_args + ['--private-access=true', '--public-access=false']
+            privatize_args = privatize_args + get_region_arg(connection_info)
+            privatize_c = EksctlCommand(privatize_args, connection_info)
+            if privatize_c.run_and_log() != 0:
+                raise Exception("Failed to make cluster fully private")
+
         args = ['get', 'cluster']
         args = args + ['--name', self.cluster_id]
         args = args + get_region_arg(connection_info)

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -176,12 +176,15 @@ class MyCluster(Cluster):
                     describe_resource_args = describe_resource_args + ['--stack-name', stack_name]
                     describe_resource_args = describe_resource_args + ['--logical-resource-id', resource_id]
                     describe_resource_c = AwsCommand(describe_resource_args, connection_info)
-                    describe_resource = json.loads(describe_resource_c.run_and_get_output()).get('StackResourceDetail', {})
-                    sg_id = describe_resource.get("PhysicalResourceId", None)
-                    logging.info("%s SG is %s" % (resource_id, sg_id))
-                    if sg_id is not None and sg_id != injected_security_group:
-                        sg_ids.append(sg_id)
-                    
+                    try:
+                        describe_resource = json.loads(describe_resource_c.run_and_get_output()).get('StackResourceDetail', {})
+                        sg_id = describe_resource.get("PhysicalResourceId", None)
+                        logging.info("%s SG is %s" % (resource_id, sg_id))
+                        if sg_id is not None and sg_id != injected_security_group:
+                            sg_ids.append(sg_id)
+                    except:
+                        logging.warn("Not able to get SG id for %s" % resource_id)
+                        
                 # attach a rule to the shared SG so that the DSS VM can access it (and the VPC endpoints that use it)
                 if len(injected_security_group) > 0:
                     inbound = ['--source-group', injected_security_group]

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -94,20 +94,27 @@ class MyCluster(Cluster):
                 yaml_dict['vpc']['clusterEndpoints'] = None
                 
                 # make sure we have a security group to use as shared security group
+                # the issue being that eksctl puts this guy on the private VPC endpoints
+                # and if you don't control it, then the DSS VM will have no access to the 
+                # endpoints, and eksctl will start failing on calls to EC2
                 security_group = self.config.get('sharedSG', '').strip()
                 if len(security_group) == 0:
                     raise Exception("A shared SG is needed to guarantee that the control plane will be accessible from the DSS VM")
                 yaml_dict['vpc']['sharedNodeSecurityGroup'] = security_group
+                                
                 
-            if node_pool.get('addPreBootstrapCommands', False) and not _is_none_or_blank(node_pool.get("preBootstrapCommands", "")):
-                # has to be added in the yaml, there is no command line flag for that
-                commands = node_pool.get("preBootstrapCommands", "")
+            def add_pre_bootstrap_commands(commands, yaml_dict):
                 for node_pool_dict in yaml_dict['managedNodeGroups']:
                     if node_pool_dict.get('preBootstrapCommands') is None:
                         node_pool_dict['preBootstrapCommands'] = []
                     for command in commands.split('\n'):
                         if len(command.strip()) > 0:
                             node_pool_dict['preBootstrapCommands'].append(command)
+                
+            if node_pool.get('addPreBootstrapCommands', False) and not _is_none_or_blank(node_pool.get("preBootstrapCommands", "")):
+                # has to be added in the yaml, there is no command line flag for that
+                commands = node_pool.get("preBootstrapCommands", "")
+                add_pre_bootstrap_commands(commands, yaml_dict)
 
         # whatever the setting, make the cluster from the yaml config
         yaml_loc = os.path.join(os.getcwd(), self.cluster_id +'_config.yaml')

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -97,20 +97,20 @@ class MyCluster(Cluster):
                 yaml_dict['vpc'] = yaml_dict.get('vpc', {})
                 yaml_dict['vpc']['clusterEndpoints'] = None
                 
-                # make sure we have a security group to use as shared security group
-                # the issue being that eksctl puts this guy on the private VPC endpoints
-                # and if you don't control it, then the DSS VM will have no access to the 
-                # endpoints, and eksctl will start failing on calls to EC2
-                control_plane_security_group = self.config.get('controlPlaneSG', '').strip()
-                shared_security_group = self.config.get('sharedSG', '').strip()
-                if len(control_plane_security_group) > 0:
-                    yaml_dict['vpc']['securityGroup'] = control_plane_security_group
-                elif len(shared_security_group) > 0:
-                    yaml_dict['vpc']['sharedNodeSecurityGroup'] = shared_security_group
-                else:
-                    # we'll need to make eksctl able to reach the stuff bearing the 
-                    # SG created by eksctl
-                    attach_vm_to_security_groups = True
+            # make sure we have a security group to use as shared security group
+            # the issue being that eksctl puts this guy on the private VPC endpoints
+            # and if you don't control it, then the DSS VM will have no access to the 
+            # endpoints, and eksctl will start failing on calls to EC2
+            control_plane_security_group = networking_settings.get('controlPlaneSG', '').strip()
+            shared_security_group = networking_settings.get('sharedSG', '').strip()
+            if len(control_plane_security_group) > 0:
+                yaml_dict['vpc']['securityGroup'] = control_plane_security_group
+            elif len(shared_security_group) > 0:
+                yaml_dict['vpc']['sharedNodeSecurityGroup'] = shared_security_group
+            elif self.config.get('privateCluster', False):
+                # we'll need to make eksctl able to reach the stuff bearing the 
+                # SG created by eksctl
+                attach_vm_to_security_groups = True
                 
             def add_pre_bootstrap_commands(commands, yaml_dict):
                 for node_pool_dict in yaml_dict['managedNodeGroups']:

--- a/python-lib/dku_utils/config_parser.py
+++ b/python-lib/dku_utils/config_parser.py
@@ -1,7 +1,7 @@
 # Provide some utility methods to parse the saved configuration, clean it,
 # normalize it and return in a predefined format (ex: command line args)
 
-import os, logging
+import os, logging, requests
 from dku_utils.access import _has_not_blank_property
 
 
@@ -29,11 +29,22 @@ def get_security_groups_arg(config):
 
 REGION_ARG = "--region"
 
-def get_region_arg(connection_info):
+def get_region_fallback_to_metadata(connection_info):
     if _has_not_blank_property(connection_info, 'region'):
         logging.info("Using region %s" % connection_info['region'])
-        return [REGION_ARG, connection_info['region']]
-    elif 'AWS_DEFAULT_REGION' in os.environ:
+        return connection_info['region']
+    if 'AWS_DEFAULT_REGION' in os.environ:
         logging.info("Using AWS_DEFAULT_REGION %s" % os.environ['AWS_DEFAULT_REGION'])
-        return [REGION_ARG, os.environ['AWS_DEFAULT_REGION']]
+        return os.environ['AWS_DEFAULT_REGION']
+    try:
+        identity = request.get("http://169.254.169.254/latest/dynamic/instance-identity/document")
+        return json.loads(document).get('region')
+    except Exception as e:
+        logging.error("Failed to get region from metadata: %s" % str(e))
+    return None
+
+def get_region_arg(connection_info):
+    region = get_region_fallback_to_metadata(connection_info)
+    if region is not None:
+        return [REGION_ARG, region]
     return []

--- a/python-lib/dku_utils/config_parser.py
+++ b/python-lib/dku_utils/config_parser.py
@@ -1,7 +1,7 @@
 # Provide some utility methods to parse the saved configuration, clean it,
 # normalize it and return in a predefined format (ex: command line args)
 
-import os, logging, requests
+import os, logging, requests, json
 from dku_utils.access import _has_not_blank_property
 
 
@@ -37,7 +37,7 @@ def get_region_fallback_to_metadata(connection_info):
         logging.info("Using AWS_DEFAULT_REGION %s" % os.environ['AWS_DEFAULT_REGION'])
         return os.environ['AWS_DEFAULT_REGION']
     try:
-        identity = request.get("http://169.254.169.254/latest/dynamic/instance-identity/document")
+        document = requests.get("http://169.254.169.254/latest/dynamic/instance-identity/document").text
         return json.loads(document).get('region')
     except Exception as e:
         logging.error("Failed to get region from metadata: %s" % str(e))
@@ -48,3 +48,12 @@ def get_region_arg(connection_info):
     if region is not None:
         return [REGION_ARG, region]
     return []
+
+def get_private_ip_from_metadata():
+    try:
+        document = requests.get("http://169.254.169.254/latest/dynamic/instance-identity/document").text
+        return json.loads(document).get('privateIp')
+    except Exception as e:
+        logging.error("Failed to get region from metadata: %s" % str(e))
+    return None
+

--- a/python-lib/dku_utils/node_pool.py
+++ b/python-lib/dku_utils/node_pool.py
@@ -21,4 +21,8 @@ def get_node_pool_args(node_pool):
     if node_pool.get('useSpotInstances', False):
         args = args + ['--managed', '--spot']
 
+    if len(node_pool.get('publicKeyName', '')) > 0:
+        args = args + ["--ssh-access"]
+        args = args + ['--ssh-public-key', node_pool.get('publicKeyName', '')]
+        
     return args

--- a/python-runnables/add-node-pool/runnable.py
+++ b/python-runnables/add-node-pool/runnable.py
@@ -65,7 +65,7 @@ class MyRunnable(Runnable):
         
         # second step: add the stuff that has no equivalent command line arg, and run the 
         # eksctl command on the yaml config
-        if not _is_none_or_blank(node_pool.get("preBootstrapCommands", "")):
+        if node_pool.get('addPreBootstrapCommands', False) and not _is_none_or_blank(node_pool.get("preBootstrapCommands", "")):
             # has to be added in the yaml, there is no command line flag for that
             commands = node_pool.get("preBootstrapCommands", "")
             for node_pool_dict in yaml_dict['managedNodeGroups']:

--- a/python-runnables/add-node-pool/runnable.py
+++ b/python-runnables/add-node-pool/runnable.py
@@ -1,6 +1,6 @@
 from dataiku.runnables import Runnable
 import dataiku
-import os, json, logging
+import os, json, logging, yaml
 from dku_kube.autoscaler import add_autoscaler_if_needed
 from dku_kube.gpu_driver import add_gpu_driver_if_needed
 from dku_aws.eksctl_command import EksctlCommand
@@ -8,6 +8,7 @@ from dku_aws.aws_command import AwsCommand
 from dku_utils.cluster import get_cluster_from_dss_cluster, get_connection_info
 from dku_utils.config_parser import get_security_groups_arg, get_region_arg
 from dku_utils.node_pool import get_node_pool_args
+from dku_utils.access import _is_none_or_blank
 
 class MyRunnable(Runnable):
     def __init__(self, project_key, config, plugin_config):
@@ -36,8 +37,9 @@ class MyRunnable(Runnable):
         
         node_group_id = self.config.get('nodeGroupId', None)
         
+        # first pass: get the yaml config corresponding to the command line args
         args = ['create', 'nodegroup']
-        args = args + ['-v', '4']
+        args = args + ['-v', '3'] # not -v 4 otherwise there is a debug line in the beginning of the output
         args = args + ['--cluster', cluster_id]
         if node_group_id is not None and len(node_group_id) > 0:
             args = args + ['--name', node_group_id]
@@ -54,6 +56,33 @@ class MyRunnable(Runnable):
 
         node_pool = self.config.get('nodePool', {})
         args += get_node_pool_args(node_pool)
+
+        c = EksctlCommand(args + ["--dry-run"], connection_info)
+        yaml_spec = c.run_and_get_output()
+        logging.info("Got spec:\n%s" % yaml_spec)
+
+        yaml_dict = yaml.safe_load(yaml_spec)
+        
+        # second step: add the stuff that has no equivalent command line arg, and run the 
+        # eksctl command on the yaml config
+        if not _is_none_or_blank(node_pool.get("preBootstrapCommands", "")):
+            # has to be added in the yaml, there is no command line flag for that
+            commands = node_pool.get("preBootstrapCommands", "")
+            for node_pool_dict in yaml_dict['managedNodeGroups']:
+                if node_pool_dict.get('preBootstrapCommands') is None:
+                    node_pool_dict['preBootstrapCommands'] = []
+                for command in commands.split('\n'):
+                    if len(command.strip()) > 0:
+                        node_pool_dict['preBootstrapCommands'].append(command)
+        
+        yaml_loc = os.path.join(os.getcwd(), cluster_id +'_config.yaml')
+        with open(yaml_loc, 'w') as outfile:
+            yaml.dump(yaml_dict, outfile, default_flow_style=False)
+        logging.info("Final spec\n%s" % yaml.dump(yaml_dict))
+
+        args = ['create', 'nodegroup']
+        args = args + ['-v', '4']
+        args = args + ['-f', yaml_loc]
 
         c = EksctlCommand(args, connection_info)
         if c.run_and_log() != 0:


### PR DESCRIPTION
[sc-98302]

added a checkbox for making so called "fully-private" eks clusters ( [see what the FEs say about it](https://analytics.dataiku.com/projects/DATAOPSWIKI/wiki/197/DSS%20with%20full%20private%20EKS) )

when using a fully private cluster, put some SG of the DSS VM as shared SG in the cluster so that the VM can access the cluster, otherwise eksctl will create a SG from scratch and your VM won't have access to the cluster...