### PR TITLE
[sc-49956] log API calls

### DIFF
--- a/python-clusters/attach-eks-cluster/cluster.py
+++ b/python-clusters/attach-eks-cluster/cluster.py
@@ -68,6 +68,9 @@ users:
         with open(kube_config_path, 'w') as f:
             f.write(kube_config_str)
 
+        logging.info("Cluster attached. Cluster configuration:")
+        logging.info(kube_config_str)
+
         setup_creds_env(kube_config_path, connection_info, self.config)
 
         kube_config = yaml.safe_load(kube_config_str)

--- a/python-clusters/attach-eks-cluster/cluster.py
+++ b/python-clusters/attach-eks-cluster/cluster.py
@@ -32,6 +32,9 @@ class MyCluster(Cluster):
         c = EksctlCommand(args, connection_info)
         cluster_info = json.loads(c.run_and_get_output())[0]
 
+        logging.info("Retrieved information about the cluster:")
+        logging.info(json.dumps(cluster_info, indent=4))
+
         kube_config_str = """
 apiVersion: v1
 clusters:
@@ -68,7 +71,7 @@ users:
         with open(kube_config_path, 'w') as f:
             f.write(kube_config_str)
 
-        logging.info("Cluster attached. Cluster configuration:")
+        logging.info("Cluster attached. Cluster configuration (Kube config):")
         logging.info(kube_config_str)
 
         setup_creds_env(kube_config_path, connection_info, self.config)

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -99,6 +99,9 @@ class MyCluster(Cluster):
         c = EksctlCommand(args, connection_info)
         cluster_info = json.loads(c.run_and_get_output())[0]
 
+        logging.info("Cluster created with configuration:")
+        logging.info(json.dumps(cluster_info))
+
         with open(kube_config_path, "r") as f:
             kube_config = yaml.safe_load(f)
 

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -100,7 +100,7 @@ class MyCluster(Cluster):
         cluster_info = json.loads(c.run_and_get_output())[0]
 
         logging.info("Cluster created with configuration:")
-        logging.info(json.dumps(cluster_info))
+        logging.info(json.dumps(cluster_info, indent=4))
 
         with open(kube_config_path, "r") as f:
             kube_config = yaml.safe_load(f)


### PR DESCRIPTION
[sc-49956]  The whole plugin has been checked but log lines are already present in the utility methods running the commands. This one has been added to log the cluster configuration at creation and attachment time.