### PR TITLE
[sc-107058] fix regex to find server address

### DIFF
--- a/python-runnables/test-network/runnable.py
+++ b/python-runnables/test-network/runnable.py
@@ -53,7 +53,7 @@ class MyRunnable(Runnable):
                     out, err = b.exec_cmd(cmd)
                     result =  result + '<h5>Resolve host</h5><div style="margin-left: 20px;"><div>Command</div><pre class="debug">%s</pre><div>Output</div><pre class="debug">%s</pre><div>Error</div><pre class="debug">%s</pre></div>' % (json.dumps(cmd), out, err)
                     for line in out.split('\n'):
-                        m = re.match('^Address.*\\s([0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+[^\\s]*)\\s.*$', line)
+                        m = re.match('^Address.*\\s([0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+[^\\s]*)(\\s.*)?$', line)
                         if m is not None:
                             ip = m.group(1)
                     if ip is None:

--- a/python-runnables/test-network/runnable.py
+++ b/python-runnables/test-network/runnable.py
@@ -53,6 +53,11 @@ class MyRunnable(Runnable):
                     out, err = b.exec_cmd(cmd)
                     result =  result + '<h5>Resolve host</h5><div style="margin-left: 20px;"><div>Command</div><pre class="debug">%s</pre><div>Output</div><pre class="debug">%s</pre><div>Error</div><pre class="debug">%s</pre></div>' % (json.dumps(cmd), out, err)
                     for line in out.split('\n'):
+                        # always capture the last IP in the nslookup response independently from the fact that it may be followed by a DNS name or not
+                        # Examples of matches:
+                        # Address 1: 10.0.12.28 -captured-> 10.0.12.28
+                        # or
+                        # Address 1: 10.0.12.28 ip-10-0-12-28.eu-west-1.compute.internal -captured-> 10.0.12.28
                         m = re.match('^Address.*\\s([0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+[^\\s]*)(\\s.*)?$', line)
                         if m is not None:
                             ip = m.group(1)

--- a/python-runnables/test-network/runnable.py
+++ b/python-runnables/test-network/runnable.py
@@ -58,7 +58,7 @@ class MyRunnable(Runnable):
                         # Address 1: 10.0.12.28 -captured-> 10.0.12.28
                         # or
                         # Address 1: 10.0.12.28 ip-10-0-12-28.eu-west-1.compute.internal -captured-> 10.0.12.28
-                        m = re.match('^Address.*\\s([0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+[^\\s]*)(\\s.*)?$', line)
+                        m = re.match('^Address.*\\s(\\d+\\.\\d+\\.\\d+\\.\\d+)', line)
                         if m is not None:
                             ip = m.group(1)
                     if ip is None:


### PR DESCRIPTION
Customer was having an issue as the server IP to be chosen was not followed by text and the regex capturing the IPs was not matching that.

In order to reproduce: you can use [this plugin](https://github.com/dataiku/dss-plugin-eks-clusters/files/11065052/eks-plugin-repro.zip) that does not send the `nslookup` command and supplies to the rest of the code the content that was causing the issue on customer side **BUT the regex is still problematic**

In order to validate: you can use  [this plugin](https://github.com/dataiku/dss-plugin-eks-clusters/files/11065076/eks-plugin-fix.zip) that does not send the `nslookup` command and supplies to the rest of the code the content that was causing the issue on customer side **BUT the regex is fixed**
