### PR TITLE
[SC-132075] eks clusters platform necessary update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 1.1.2 - Internal release
+- Added support for Python 3.8, 3.9, 3.10 (experimental), 3.11 (experimental) 
+
 ## Version 1.1.1 - Bugfix release
 - Add support of v1beta1 apiVersion when attaching
 

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,6 +1,7 @@
 {
-  "acceptedPythonInterpreters": ["PYTHON27", "PYTHON36", "PYTHON37"],
+  "acceptedPythonInterpreters": ["PYTHON27", "PYTHON36", "PYTHON37", "PYTHON38", "PYTHON39", "PYTHON310", "PYTHON311"],
   "forceConda": false,
   "installCorePackages": true,
-  "installJupyterSupport": false
+  "installJupyterSupport": false,
+  "corePackagesSet": "AUTO"
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "eks-clusters",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "meta": {
         "label": "EKS clusters",
         "description": "Interact with Amazon Elastic Kubernetes Service clusters",

--- a/python-lib/dku_utils/access.py
+++ b/python-lib/dku_utils/access.py
@@ -1,5 +1,8 @@
 from six import text_type
-from collections import Mapping, Iterable
+try:
+    from collections.abc import Mapping, Iterable
+except ImportError:
+    from collections import Mapping, Iterable
 from io import StringIO, BytesIO
 import sys
 

--- a/python-runnables/install-alb-controller/runnable.py
+++ b/python-runnables/install-alb-controller/runnable.py
@@ -21,7 +21,12 @@ def make_html(command_outputs):
         divs.append(out_html)
         if command_output[1] != 0 and not _is_none_or_blank(command_output[3]):
             divs.append(err_html)
-    return '\n'.join(divs).decode('utf8')
+    html = '\n'.join(divs)
+    try:
+        html.decode('utf8')
+    except (UnicodeDecodeError, AttributeError):
+        pass
+    return html
 
 class InstallAlb(Runnable):
     """
@@ -134,7 +139,7 @@ class InstallAlb(Runnable):
             return make_html(command_outputs)
 
         r = requests.get('https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.4/docs/examples/alb-ingress-controller.yaml')
-        service_data = r.content
+        service_data = r.text
         cluster_flag_pattern = '#.*cluster\\-name=.*'
         cluster_flag_replacement = '- --cluster-name=%s' % cluster_id
         service_data = re.sub(cluster_flag_pattern, cluster_flag_replacement, service_data)

--- a/python-runnables/remove-alb-controller/runnable.py
+++ b/python-runnables/remove-alb-controller/runnable.py
@@ -21,7 +21,12 @@ def make_html(command_outputs):
         divs.append(out_html)
         if command_output[1] != 0 and not _is_none_or_blank(command_output[3]):
             divs.append(err_html)
-    return '\n'.join(divs).decode('utf8')
+    html = '\n'.join(divs)
+    try:
+        html.decode('utf8')
+    except (UnicodeDecodeError, AttributeError):
+        pass
+    return html
 
 class RemoveAlb(Runnable):
     """


### PR DESCRIPTION
Tested against all available version of Python from 2.7 to 3.11.
Tests of version 3.11 were very limited because of this [issue](https://app.shortcut.com/dataiku/story/132994/inspect-getargspec-has-been-removed-in-python3-11-at-least-python-connectors-are-broken).
For all other versions:
- tested all actions
- tested python notebooks
- tested recipes
- tested STS assume role
- model training

Tested model training with GPU with Python v 3.8 and 3.9.