### PR TITLE
[sc-135611] Wait until resources are deleted when deleting a nodegroup

### DIFF
--- a/python-runnables/resize-node-pool/runnable.py
+++ b/python-runnables/resize-node-pool/runnable.py
@@ -65,6 +65,7 @@ class MyRunnable(Runnable):
             args = args + ['--cluster', cluster_id]
             args = args + ['--name', node_group_id]
             args = args + get_region_arg(connection_info)
+            args = args + ['--wait']  # wait until resources are completely deleted
 
             c = EksctlCommand(args, connection_info)
             rv, out, err = c.run_and_get()


### PR DESCRIPTION
This PR fixes a very small bug in the "Resize cluster" macro: when resizing a nodegroup to have 0 nodes, we don't wait until the nodegroup is effectively deleted, but we return once the deletion of the CloudFormation stack is initiated. This might be misleading, so this PR adds the `--wait` flag to the `eksctl delete nodegroup` command, to wait until resources are completely deleted.