### PR TITLE
[sc-135359] security group is taken into account when adding a new node group through macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 1.2.0 - Internal release
 - Added support for Python 3.8, 3.9, 3.10 (experimental), 3.11 (experimental)
 - Python 2.7 is now deprecated
+- Macro `Add node pool` now adds the node pool in the cluster security groups
 
 ## Version 1.1.1 - Bugfix release
 - Add support of v1beta1 apiVersion when attaching

--- a/python-lib/dku_utils/config_parser.py
+++ b/python-lib/dku_utils/config_parser.py
@@ -4,7 +4,7 @@
 import os, logging, requests, json
 from dku_utils.access import _has_not_blank_property
 
-
+NETWORK_SETTINGS = 'networkingSettings'
 SECURITY_GROUPS = 'securityGroups'
 SECURITY_GROUPS_ARG = '--node-security-groups'
 
@@ -18,7 +18,8 @@ def get_security_groups_arg(config):
     """
     if config is None or not isinstance(config, dict):
         raise Exception("config can not be null and has to be a dictionary.")
-    params = config.get(SECURITY_GROUPS, [])
+    network_params = config.get(NETWORK_SETTINGS, {})
+    params = network_params.get(SECURITY_GROUPS, [])
     if len(params) == 0:
         return []
 

--- a/python-lib/dku_utils/config_parser.py
+++ b/python-lib/dku_utils/config_parser.py
@@ -4,7 +4,6 @@
 import os, logging, requests, json
 from dku_utils.access import _has_not_blank_property
 
-NETWORK_SETTINGS = 'networkingSettings'
 SECURITY_GROUPS = 'securityGroups'
 SECURITY_GROUPS_ARG = '--node-security-groups'
 
@@ -18,8 +17,7 @@ def get_security_groups_arg(config):
     """
     if config is None or not isinstance(config, dict):
         raise Exception("config can not be null and has to be a dictionary.")
-    network_params = config.get(NETWORK_SETTINGS, {})
-    params = network_params.get(SECURITY_GROUPS, [])
+    params = config.get(SECURITY_GROUPS, [])
     if len(params) == 0:
         return []
 

--- a/python-runnables/add-node-pool/runnable.py
+++ b/python-runnables/add-node-pool/runnable.py
@@ -52,7 +52,7 @@ class MyRunnable(Runnable):
         if dss_cluster_config.get('privateNetworking', False) or self.config.get('privateNetworking', None):
             args = args + ['--node-private-networking']
             
-        args += get_security_groups_arg(dss_cluster_config['config'].get('networkSettings', {}))
+        args += get_security_groups_arg(dss_cluster_config['config'].get('networkingSettings', {}))
 
         node_pool = self.config.get('nodePool', {})
         args += get_node_pool_args(node_pool)

--- a/python-runnables/add-node-pool/runnable.py
+++ b/python-runnables/add-node-pool/runnable.py
@@ -52,7 +52,7 @@ class MyRunnable(Runnable):
         if dss_cluster_config.get('privateNetworking', False) or self.config.get('privateNetworking', None):
             args = args + ['--node-private-networking']
             
-        args += get_security_groups_arg(dss_cluster_config['config'])
+        args += get_security_groups_arg(dss_cluster_config['config'].get('networkSettings', {}))
 
         node_pool = self.config.get('nodePool', {})
         args += get_node_pool_args(node_pool)


### PR DESCRIPTION
[sc-135359]

## Repro case
* documented in the card

## How to check the security group has been added to the node group correctly
### AWS Management console
* find the cloudformation stack corresponding to the node group added with the macro
* check the template and see that it contains the security group ID in section `SecurityGroupIds`

### DSS
* configure the cluster to be used by default and push base images
* create a new code env and build it for the containerized execution using the cluster
* create a new notebook and use the cluster and the code env for it
* wait for the kernel to start and see that the commands in the notebooks correctly execute
* check the pods in the cluster and see that a pod has been created for the notebook