### PR TITLE
feat: add ability to add cloudwatch managed policy to nodes

### DIFF
--- a/python-clusters/create-eks-cluster/cluster.json
+++ b/python-clusters/create-eks-cluster/cluster.json
@@ -67,6 +67,13 @@
              "defaultValue" : true
         },
         {
+            "name": "enableCloudWatchPolicy",
+            "label": "Add CloudWatch policy",
+            "description": "Add CloudWatch IAM policy to cluster instances",
+            "type": "BOOLEAN",
+            "defaultValue": false
+        },
+        {
             "name": "privateCluster",
             "label": "Fully-private",
             "type": "BOOLEAN",

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -127,6 +127,10 @@ class MyCluster(Cluster):
                 commands = node_pool.get("preBootstrapCommands", "")
                 add_pre_bootstrap_commands(commands, yaml_dict)
 
+            if self.config.get('enableCloudWatchPolicy', True):
+                for node_pool_dict in yaml_dict['managedNodeGroups']:
+                    node_pool_dict['iam']['withAddonPolicies']['cloudWatch'] = True
+
         # whatever the setting, make the cluster from the yaml config
         yaml_loc = os.path.join(os.getcwd(), self.cluster_id +'_config.yaml')
         with open(yaml_loc, 'w') as outfile:


### PR DESCRIPTION
There appears to have been an oversight in a `eksctl` [PR](https://github.com/weaveworks/eksctl/issues/5455) with the addition of the `cloudwatch:PutMetricData` managed policy being added to the service role and not the node group role.

This PR adds the ability to add this IAM policy to the node group role so that the nodes have the permissions to push metrics to CloudWatch so that alarms can be created off the back of them.