### PR TITLE
EKS parse no integer in kubectl version

### DIFF
--- a/python-lib/dku_utils/tools_version.py
+++ b/python-lib/dku_utils/tools_version.py
@@ -12,7 +12,7 @@ def get_kubectl_version_int(kubectl_version):
     regex_minor_int = re.compile("^[^0-9]*([0-9]+)")
     search_results_minor_int = re.search(regex_minor_int, kubectl_version['minor'])
     if len(search_results_minor_int.groups()) < 1:
-        raise Exception("Kubectl version found on the machine: %s. It was not possible to parse")
+        raise Exception("Kubectl version found on the machine: %s. It was not possible to parse" % (str(kubectl_version['major']) + '.' + str(kubectl_version['minor']))
     minor_int = int(search_results_minor_int.group(0))
     return int(kubectl_version['major']), minor_int
 

--- a/python-lib/dku_utils/tools_version.py
+++ b/python-lib/dku_utils/tools_version.py
@@ -7,11 +7,13 @@ def get_kubectl_version():
     return json.loads(out)['clientVersion']
 
 def get_kubectl_version_int(kubectl_version):
-    regex_minor_int = re.compile("^[^0-9]*([0-9]+).*")
-    results_minor_int = re.search(regex_minor_int, kubectl_version['minor'])
-    if len(results_minor_int) != 1:
+    # the kubectl version downloaded from Amazon website has a minor version finishing by '+'
+    # keeping only the first numeric sequence for the minor version
+    regex_minor_int = re.compile("^[^0-9]*([0-9]+)")
+    search_results_minor_int = re.search(regex_minor_int, kubectl_version['minor'])
+    if len(search_results_minor_int.groups()) < 1:
         raise Exception("Kubectl version found on the machine: %s. It was not possible to parse")
-    minor_int = int(results_minor_int[0])
+    minor_int = int(search_results_minor_int.group(0))
     return int(kubectl_version['major']), minor_int
 
 def get_authenticator_version():

--- a/python-lib/dku_utils/tools_version.py
+++ b/python-lib/dku_utils/tools_version.py
@@ -9,11 +9,15 @@ def get_kubectl_version():
 def get_kubectl_version_int(kubectl_version):
     # the kubectl version downloaded from Amazon website has a minor version finishing by '+'
     # keeping only the first numeric sequence for the minor version
-    regex_minor_int = re.compile("^[^0-9]*([0-9]+)")
+    if 'major' not in kubectl_version or 'minor' not in kubectl_version:
+        raise Exception("Kubectl version found on the machine is not correctly formatted")
+    regex_minor_int = re.compile("^[^0-9]*([0-9]+)([^0-9].*$|$)")
     search_results_minor_int = re.search(regex_minor_int, kubectl_version['minor'])
-    if len(search_results_minor_int.groups()) < 1:
-        raise Exception("Kubectl version found on the machine: %s. It was not possible to parse" % (str(kubectl_version['major']) + '.' + str(kubectl_version['minor']))
-    minor_int = int(search_results_minor_int.group(0))
+    if not search_results_minor_int:
+        raise Exception("No kubectl minor version found")
+    if not search_results_minor_int.groups():
+        raise Exception("Kubectl version found on the machine: %s. It was not possible to parse" % (str(kubectl_version['major']) + '.' + str(kubectl_version['minor'])))
+    minor_int = int(search_results_minor_int.groups()[0])
     return int(kubectl_version['major']), minor_int
 
 def get_authenticator_version():

--- a/python-lib/dku_utils/tools_version.py
+++ b/python-lib/dku_utils/tools_version.py
@@ -6,17 +6,20 @@ def get_kubectl_version():
     out, err = run_with_timeout(cmd)
     return json.loads(out)['clientVersion']
 
+def kubectl_version_to_string(kubectl_version):
+    major = str(kubectl_version['major']) if 'major' in kubectl_version else ''
+    minor = str(kubectl_version['minor']) if 'minor' in kubectl_version else ''
+    return major + '.' + minor
+
 def get_kubectl_version_int(kubectl_version):
     # the kubectl version downloaded from Amazon website has a minor version finishing by '+'
     # keeping only the first numeric sequence for the minor version
     if 'major' not in kubectl_version or 'minor' not in kubectl_version:
-        raise Exception("Kubectl version found on the machine is not correctly formatted")
+        raise Exception("Kubectl version found on the machine: %s. It is not correctly formatted" % kubectl_version_to_string(kubectl_version))
     regex_minor_int = re.compile("^[^0-9]*([0-9]+)([^0-9].*$|$)")
     search_results_minor_int = re.search(regex_minor_int, kubectl_version['minor'])
-    if not search_results_minor_int:
-        raise Exception("No kubectl minor version found")
-    if not search_results_minor_int.groups():
-        raise Exception("Kubectl version found on the machine: %s. It was not possible to parse" % (str(kubectl_version['major']) + '.' + str(kubectl_version['minor'])))
+    if not search_results_minor_int or not search_results_minor_int.groups():
+        raise Exception("Kubectl version found on the machine: %s. It was not possible to parse" % kubectl_version_to_string(kubectl_version))
     minor_int = int(search_results_minor_int.groups()[0])
     return int(kubectl_version['major']), minor_int
 


### PR DESCRIPTION
`kubectl` version provided by Amazon has a minor version finishing by '+'

this minor version is used in a comparison in a condition to decide which version of the AWS authenticator should be used

keeping only the first numeric section to consider as the minor version