### PR TITLE
Allowing plugin to define multiple node groups at cluster creation & adding labels/taints

### DIFF
--- a/parameter-sets/node-pool-request/parameter-set.json
+++ b/parameter-sets/node-pool-request/parameter-set.json
@@ -87,7 +87,7 @@
         {
             "name": "labels",
             "label": "Node Labels",
-            "description": "TODO: Test empty map keys/values | https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/",
+            "description": "https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/",
             "type": "MAP",
             "mandatory": false
         },

--- a/parameter-sets/node-pool-request/parameter-set.json
+++ b/parameter-sets/node-pool-request/parameter-set.json
@@ -85,6 +85,49 @@
             "type": "STRING"
         },
         {
+            "name": "labels",
+            "label": "Node Labels",
+            "description": "TODO: Test empty map keys/values | https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/",
+            "type": "MAP",
+            "mandatory": false
+        },
+        {
+            "name": "taints",
+            "label": "Node Taints",
+            "description": "WARNING: MUST CREATE AT LEAST ONE NODE POOL WITHOUT TAINTS. https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/",
+            "mandatory": false,
+            "type": "OBJECT_LIST",
+            "subParams": [
+                {
+                    "type": "SEPARATOR",
+                    "label": "Enter your taints"
+                },
+                {
+                    "name": "key",
+                    "type": "STRING",
+                    "label": "Key",
+                    "mandatory": true
+                },
+                {
+                    "name": "value",
+                    "type": "STRING",
+                    "label": "Value",
+                    "mandatory": false
+                },
+                {
+                    "name": "effect",
+                    "type": "SELECT",
+                    "label": "Effect",
+                    "selectChoices": [
+                        { "value": "NO_SCHEDULE", "label": "NoSchedule"},
+                        { "value": "NO_EXECUTE", "label": "NoExecute"},
+                        { "value": "PREFER_NO_SCHEDULE", "label": "PreferNoSchedule"}
+                    ],
+                    "mandatory": true
+                }
+            ]
+        },
+        {
             "name": "enableGPU",
             "label": "GPU",
             "description": "Enable GPU workloads on the cluster",

--- a/parameter-sets/node-pool-request/parameter-set.json
+++ b/parameter-sets/node-pool-request/parameter-set.json
@@ -12,6 +12,13 @@
 
     "params": [
         {
+            "name": "nodeGroupId",
+            "label": "Node group",
+            "description": "Id of node group to create, if not default",
+            "type": "STRING",
+            "mandatory": false
+        },
+        {
             "name": "machineType",
             "label": "Machine type",
             "description": "EC2 instance type for the nodes. See EC2 documentation for available instance types",

--- a/parameter-sets/node-pool-request/parameter-set.json
+++ b/parameter-sets/node-pool-request/parameter-set.json
@@ -93,14 +93,14 @@
         },
         {
             "name": "labels",
-            "label": "Node Labels",
+            "label": "Node labels",
             "description": "https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/",
             "type": "MAP",
             "mandatory": false
         },
         {
             "name": "taints",
-            "label": "Node Taints",
+            "label": "Node taints",
             "description": "WARNING: MUST CREATE AT LEAST ONE NODE POOL WITHOUT TAINTS. https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/",
             "mandatory": false,
             "type": "OBJECT_LIST",
@@ -126,9 +126,9 @@
                     "type": "SELECT",
                     "label": "Effect",
                     "selectChoices": [
-                        { "value": "NoSchedule", "label": "NoSchedule"},
-                        { "value": "NoExecute", "label": "NoExecute"},
-                        { "value": "PreferNoSchedule", "label": "PreferNoSchedule"}
+                        {"value": "NoSchedule", "label": "NoSchedule"},
+                        {"value": "NoExecute", "label": "NoExecute"},
+                        {"value": "PreferNoSchedule", "label": "PreferNoSchedule"}
                     ],
                     "mandatory": true,
                     "defaultValue": "NoSchedule"

--- a/parameter-sets/node-pool-request/parameter-set.json
+++ b/parameter-sets/node-pool-request/parameter-set.json
@@ -119,9 +119,9 @@
                     "type": "SELECT",
                     "label": "Effect",
                     "selectChoices": [
-                        { "value": "NO_SCHEDULE", "label": "NoSchedule"},
-                        { "value": "NO_EXECUTE", "label": "NoExecute"},
-                        { "value": "PREFER_NO_SCHEDULE", "label": "PreferNoSchedule"}
+                        { "value": "NoSchedule", "label": "NoSchedule"},
+                        { "value": "NoExecute", "label": "NoExecute"},
+                        { "value": "PreferNoSchedule", "label": "PreferNoSchedule"}
                     ],
                     "mandatory": true
                 }

--- a/parameter-sets/node-pool-request/parameter-set.json
+++ b/parameter-sets/node-pool-request/parameter-set.json
@@ -130,7 +130,8 @@
                         { "value": "NoExecute", "label": "NoExecute"},
                         { "value": "PreferNoSchedule", "label": "PreferNoSchedule"}
                     ],
-                    "mandatory": true
+                    "mandatory": true,
+                    "defaultValue": "NoSchedule"
                 }
             ]
         },

--- a/parameter-sets/node-pool-request/parameter-set.json
+++ b/parameter-sets/node-pool-request/parameter-set.json
@@ -13,7 +13,7 @@
     "params": [
         {
             "name": "nodeGroupId",
-            "label": "Node group",
+            "label": "Node group ID",
             "description": "Id of node group to create, if not default",
             "type": "STRING",
             "mandatory": false

--- a/python-clusters/create-eks-cluster/cluster.json
+++ b/python-clusters/create-eks-cluster/cluster.json
@@ -42,7 +42,7 @@
         },
         {
             "name": "nodePools",
-            "label": "Node pools to create in the cluster",
+            "label": "Node pools",
             "type": "PRESETS",
             "parameterSetId" : "node-pool-request",
             "mandatory" : false

--- a/python-clusters/create-eks-cluster/cluster.json
+++ b/python-clusters/create-eks-cluster/cluster.json
@@ -41,9 +41,9 @@
             "label": "Cluster nodes"
         },
         {
-            "name": "nodePool",
-            "label": "Initial node pool",
-            "type": "PRESET",
+            "name": "nodePools",
+            "label": "Node pools to create in the cluster",
+            "type": "PRESETS",
             "parameterSetId" : "node-pool-request",
             "mandatory" : false
         },

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -131,7 +131,7 @@ class MyCluster(Cluster):
 
             for node_pool in node_pools[1:]:
                 yaml_node_pool = get_node_pool_yaml(node_pool)
-                yaml['managedNodeGroups'].append(yaml_node_pool)
+                yaml_dict['managedNodeGroups'].append(yaml_node_pool)
 
 
         # whatever the setting, make the cluster from the yaml config

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -71,7 +71,7 @@ class MyCluster(Cluster):
             args += get_security_groups_arg(networking_settings)
 
             if len(node_pools) > 0:
-                args += ['--without-node-group']
+                args += ['--without-nodegroup']
 
             if not _is_none_or_blank(k8s_version):
                 args = args + ['--version', k8s_version.strip()]

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -75,7 +75,7 @@ class MyCluster(Cluster):
 
             if not _is_none_or_blank(k8s_version):
                 args = args + ['--version', k8s_version.strip()]
-                
+
             c = EksctlCommand(args + ["--dry-run"], connection_info)
             yaml_spec = c.run_and_get_output()
             logging.info("Got spec:\n%s" % yaml_spec)
@@ -94,7 +94,7 @@ class MyCluster(Cluster):
                     yaml_dict['managedNodeGroups'].append(yaml_node_pool)
 
                 yaml_node_pool_loc = os.path.join(os.getcwd(), self.cluster_id +'_config_with_node_pools.yaml')
-                with open(yaml_loc, 'w') as outfile:
+                with open(yaml_node_pool_loc, 'w') as outfile:
                     yaml.dump(yaml_dict, outfile, default_flow_style=False)
 
                 args = ['create', 'cluster']

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -87,9 +87,10 @@ class MyCluster(Cluster):
             if len(node_pools) > 0:
                 yaml_dict['managedNodeGroups'] = yaml_dict.get('managedNodeGroups', [])
                 for idx, node_pool in enumerate(node_pools, 0):
-                    yaml_node_pool = get_node_pool_yaml(node_pool, networking_settings)
-                    yaml_node_pool['name'] = "%s-ng-%s" % (self.cluster_id, idx)
-                    yaml_dict['managedNodeGroups'].append(yaml_node_pool)
+                    if node_pool:
+                        yaml_node_pool = get_node_pool_yaml(node_pool, networking_settings)
+                        yaml_node_pool['name'] = "%s-ng-%s" % (self.cluster_id, idx)
+                        yaml_dict['managedNodeGroups'].append(yaml_node_pool)
 
                 yaml_node_pool_loc = os.path.join(os.getcwd(), self.cluster_id +'_config_with_node_pools.yaml')
                 with open(yaml_node_pool_loc, 'w') as outfile:

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -12,7 +12,7 @@ from dku_kube.metrics_server import install_metrics_server
 from dku_utils.cluster import make_overrides, get_connection_info
 from dku_utils.access import _is_none_or_blank
 from dku_utils.config_parser import get_security_groups_arg, get_region_arg, get_private_ip_from_metadata
-from dku_utils.node_pool import get_node_pool_args, get_node_pool_yaml
+from dku_utils.node_pool import get_node_pool_yaml
 
 class MyCluster(Cluster):
     def __init__(self, cluster_id, cluster_name, config, plugin_config, global_settings):

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -11,7 +11,7 @@ from dku_kube.gpu_driver import add_gpu_driver_if_needed
 from dku_kube.metrics_server import install_metrics_server
 from dku_utils.cluster import make_overrides, get_connection_info
 from dku_utils.access import _is_none_or_blank
-from dku_utils.config_parser import get_security_groups_arg, get_region_arg, get_private_ip_from_metadata
+from dku_utils.config_parser import get_region_arg, get_private_ip_from_metadata
 from dku_utils.node_pool import get_node_pool_yaml
 
 class MyCluster(Cluster):
@@ -68,8 +68,6 @@ class MyCluster(Cluster):
             if len(subnets) > 0:
                 args = args + ['--vpc-public-subnets', ','.join(subnets)]
 
-            args += get_security_groups_arg(networking_settings)
-
             if len(node_pools) > 0:
                 args += ['--without-nodegroup']
 
@@ -89,6 +87,8 @@ class MyCluster(Cluster):
             if len(node_pools) > 0:
                 yaml_dict['managedNodeGroups'] = yaml_dict.get('managedNodeGroups', [])
                 for idx, node_pool in enumerate(node_pools, 0):
+                    node_pool['securityGroups'] = networking_settings.get('securityGroups', [])
+                    node_pool['privateNetworking'] = networking_settings.get('privateNetworking', False)
                     yaml_node_pool = get_node_pool_yaml(node_pool)
                     yaml_node_pool['name'] = "%s-ng-%s" % (self.cluster_id, idx)
                     yaml_dict['managedNodeGroups'].append(yaml_node_pool)

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -59,9 +59,9 @@ class MyCluster(Cluster):
             args = args + get_region_arg(connection_info)
             args = args + ['--full-ecr-access']
 
-            subnets = networking_settings.get('subnets', [])
+            subnets = map(networking_settings.get('subnets', []), lambda subnet_id: subnet_id.strip())
             if networking_settings.get('privateNetworking', False):
-                private_subnets = networking_settings.get('privateSubnets', [])
+                private_subnets = map(networking_settings.get('privateSubnets', []), lambda private_subnet_id: private_subnet_id.strip())
                 if len(private_subnets) > 0:
                     args = args + ['--vpc-private-subnets', ','.join(private_subnets)]
             if len(subnets) > 0:
@@ -80,11 +80,9 @@ class MyCluster(Cluster):
             
             yaml_dict = yaml.safe_load(yaml_spec)
 
-            # Once we generated the yaml configuration for the cluster, we can add the required specs for all node groups
+            # Once we generated the yaml configuration for the cluster, we can add the required specs for each node group
             # and do a second dry-run with the initial generated configuration file.
-            # This allows to fill in the configuration for the node groups.
-            # The CLI can only accommodate for a single initial node group on cluster creation, so we have to use the yaml configuration file.
-            if len(node_pools) > 0:
+            if node_pools:
                 yaml_dict['managedNodeGroups'] = yaml_dict.get('managedNodeGroups', [])
                 for idx, node_pool in enumerate(node_pools, 0):
                     if node_pool:

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -59,9 +59,9 @@ class MyCluster(Cluster):
             args = args + get_region_arg(connection_info)
             args = args + ['--full-ecr-access']
 
-            subnets = map(networking_settings.get('subnets', []), lambda subnet_id: subnet_id.strip())
+            subnets = list(map(lambda subnet_id: subnet_id.strip(), networking_settings.get('subnets', [])))
             if networking_settings.get('privateNetworking', False):
-                private_subnets = map(networking_settings.get('privateSubnets', []), lambda private_subnet_id: private_subnet_id.strip())
+                private_subnets = list(map(lambda private_subnet_id: private_subnet_id.strip(), networking_settings.get('privateSubnets', [])))
                 if len(private_subnets) > 0:
                     args = args + ['--vpc-private-subnets', ','.join(private_subnets)]
             if len(subnets) > 0:

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -90,7 +90,7 @@ class MyCluster(Cluster):
                 yaml_dict['managedNodeGroups'] = yaml_dict.get('managedNodeGroups', [])
                 for idx, node_pool in enumerate(node_pools, 0):
                     yaml_node_pool = get_node_pool_yaml(node_pool)
-                    yaml_node_pool['name'] = "%s-ng-%s" % self.cluster_id, idx
+                    yaml_node_pool['name'] = "%s-ng-%s" % (self.cluster_id, idx)
                     yaml_dict['managedNodeGroups'].append(yaml_node_pool)
 
                 yaml_node_pool_loc = os.path.join(os.getcwd(), self.cluster_id +'_config_with_node_pools.yaml')

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -89,7 +89,7 @@ class MyCluster(Cluster):
                 for idx, node_pool in enumerate(node_pools, 0):
                     if node_pool:
                         yaml_node_pool = get_node_pool_yaml(node_pool, networking_settings)
-                        yaml_node_pool['name'] = "%s-ng-%s" % (self.cluster_id, idx)
+                        yaml_node_pool['name'] = node_pool.get('nodeGroupId', "%s-ng-%s" % (self.cluster_id, idx))
                         yaml_dict['managedNodeGroups'].append(yaml_node_pool)
 
                 yaml_node_pool_loc = os.path.join(os.getcwd(), self.cluster_id +'_config_with_node_pools.yaml')

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -89,7 +89,7 @@ class MyCluster(Cluster):
                 for idx, node_pool in enumerate(node_pools, 0):
                     node_pool['securityGroups'] = networking_settings.get('securityGroups', [])
                     node_pool['privateNetworking'] = networking_settings.get('privateNetworking', False)
-                    yaml_node_pool = get_node_pool_yaml(node_pool)
+                    yaml_node_pool = get_node_pool_yaml(node_pool, networking_settings)
                     yaml_node_pool['name'] = "%s-ng-%s" % (self.cluster_id, idx)
                     yaml_dict['managedNodeGroups'].append(yaml_node_pool)
 

--- a/python-lib/dku_kube/gpu_driver.py
+++ b/python-lib/dku_kube/gpu_driver.py
@@ -13,7 +13,7 @@ def has_gpu_driver(kube_config_path):
 
 def add_gpu_driver_if_needed(cluster_id, kube_config_path, connection_info):
     if not has_gpu_driver(kube_config_path) and not check_eksctl_version(connection_info):
-        cmd = ['kubectl', 'apply', '-f', "https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/master/nvidia-device-plugin.yml"]
+        cmd = ['kubectl', 'apply', '-f', "https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/main/nvidia-device-plugin.yml"]
 
         logging.info("Install NVIDIA GPU drivers with : %s" % json.dumps(cmd))
         env = os.environ.copy()

--- a/python-lib/dku_utils/node_pool.py
+++ b/python-lib/dku_utils/node_pool.py
@@ -88,7 +88,7 @@ def get_node_pool_yaml(node_pool, networking_settings):
 
     if networking_settings.get('securityGroups', []):
         yaml['securityGroups'] = {
-            'attachIDs': map(networking_settings['securityGroups'], lambda security_group: security_group.strip())
+            'attachIDs': list(map(lambda security_group: security_group.strip(), networking_settings['securityGroups']))
         }
     yaml['privateNetworking'] = networking_settings.get('privateNetworking', False)
 

--- a/python-lib/dku_utils/node_pool.py
+++ b/python-lib/dku_utils/node_pool.py
@@ -13,7 +13,7 @@ def get_node_pool_yaml(node_pool):
     yaml['desiredCapacity'] = node_pool.get('numNodes', 3)
     if node_pool.get('numNodesAutoscaling', False):
         yaml['iam'] = {
-            'withAddOnPolicies': {
+            'withAddonPolicies': {
                 'autoScaler': True
             }
         }
@@ -24,14 +24,17 @@ def get_node_pool_yaml(node_pool):
     yaml['spot'] = node_pool.get('useSpotInstances', False)
 
     sshPublicKeyName = node_pool.get('publicKeyName', '')
-    if len(sshPublicKeyName) > 0:
+    if not _is_none_or_blank(sshPublicKeyName):
         yaml['ssh'] = {
             'allow': True,
-            'publicKey': sshPublicKeyName,
+            'publicKeyName': sshPublicKeyName,
             # Should we enable SSM??
         }
 
     if node_pool.get('addPreBootstrapCommands', False) and not _is_none_or_blank(node_pool.get("preBootstrapCommands", "")):
-        node_pool['preBootstrapCommands'] = [command.strip() for command in node_pool['preBootstrapCommands'].split('\n') if len(command.strip()) > 0]
+        yaml['preBootstrapCommands'] = yaml.get('preBootstrapCommands', [])
+        yaml['preBootstrapCommands'] += [command.strip()\
+                                          for command in node_pool['preBootstrapCommands'].split('\n')\
+                                              if not _is_none_or_blank(command.strip())]
 
     return yaml

--- a/python-lib/dku_utils/node_pool.py
+++ b/python-lib/dku_utils/node_pool.py
@@ -87,10 +87,10 @@ def build_node_pool_taints_yaml(node_pool):
     yaml_taints = []
     if len(node_pool['taints']) > 0:
         for taint in node_pool['taints']:
-            if not _is_none_or_blank(taint.key):
+            if not _is_none_or_blank(taint.get('key', '')):
                 yaml_taints.append({
-                    'key': taint.key,
-                    'value': taint.value,
-                    'effect': taint.effect
+                    'key': taint['key'],
+                    'value': taint['value'],
+                    'effect': taint['effect']
                 })
     return yaml_taints

--- a/python-lib/dku_utils/node_pool.py
+++ b/python-lib/dku_utils/node_pool.py
@@ -1,43 +1,10 @@
 from dku_utils.access import _is_none_or_blank
 
-def get_node_pool_args(node_pool):
-    args = []
-    if 'machineType' in node_pool:
-        args = args + ['--node-type', node_pool['machineType']]
-    if 'diskType' in node_pool:
-        args = args + ['--node-volume-type', node_pool['diskType']]
-    if 'diskSizeGb' in node_pool and node_pool['diskSizeGb'] > 0:
-        disk_size_gb = node_pool['diskSizeGb']
-    else:
-        disk_size_gb = 200 # also defined as default value in parameter-sets/node-pool-request/parameter-set.json
-    args = args + ['--node-volume-size', str(disk_size_gb)]
-
-    args = args + ['--nodes', str(node_pool.get('numNodes', 3))]
-    if node_pool.get('numNodesAutoscaling', False):
-        args = args + ['--asg-access']
-        args = args + ['--nodes-min', str(node_pool.get('minNumNodes', 2))]
-        args = args + ['--nodes-max', str(node_pool.get('maxNumNodes', 5))]
-
-    tags = node_pool.get('tags', {})
-    if len(tags) > 0:
-        tag_list = [key + '=' + value for key, value in tags.items()]
-        args = args + ['--tags', ','.join(tag_list)]
-
-    if node_pool.get('useSpotInstances', False):
-        args = args + ['--managed', '--spot']
-
-    if len(node_pool.get('publicKeyName', '')) > 0:
-        args = args + ["--ssh-access"]
-        args = args + ['--ssh-public-key', node_pool.get('publicKeyName', '')]
-        
-    return args
-
 def get_node_pool_yaml(node_pool):
     yaml = {}
     if 'machineType' in node_pool:
-        yaml['instanceType'] = node_pool['machineType']
-    if 'diskType' in node_pool:
-        yaml['volumeType'] = node_pool['diskType']
+        yaml['instanceType'] = node_pool.get['machineType']
+    yaml['volumeType'] = node_pool.get('diskType', 'gp2')
     if 'diskSizeGb' in node_pool and node_pool['diskSizeGb'] > 0:
         yaml['volumeSize'] = node_pool['diskSizeGb']
     else:
@@ -46,7 +13,9 @@ def get_node_pool_yaml(node_pool):
     yaml['desiredCapacity'] = node_pool.get('numNodes', 3)
     if node_pool.get('numNodesAutoscaling', False):
         yaml['iam'] = {
-            'withAddOnPolicies': True
+            'withAddOnPolicies': {
+                'autoScaler': True
+            }
         }
         yaml['minSize'] = node_pool.get('minNumNodes', 2)
         yaml['maxSize'] = node_pool.get('maxNumNodes', 2)

--- a/python-lib/dku_utils/node_pool.py
+++ b/python-lib/dku_utils/node_pool.py
@@ -1,5 +1,37 @@
 from dku_utils.access import _is_none_or_blank
 
+def get_node_pool_args(node_pool):
+    args = []
+    if 'machineType' in node_pool:
+        args = args + ['--node-type', node_pool['machineType']]
+    if 'diskType' in node_pool:
+        args = args + ['--node-volume-type', node_pool['diskType']]
+    if 'diskSizeGb' in node_pool and node_pool['diskSizeGb'] > 0:
+        disk_size_gb = node_pool['diskSizeGb']
+    else:
+        disk_size_gb = 200 # also defined as default value in parameter-sets/node-pool-request/parameter-set.json
+    args = args + ['--node-volume-size', str(disk_size_gb)]
+
+    args = args + ['--nodes', str(node_pool.get('numNodes', 3))]
+    if node_pool.get('numNodesAutoscaling', False):
+        args = args + ['--asg-access']
+        args = args + ['--nodes-min', str(node_pool.get('minNumNodes', 2))]
+        args = args + ['--nodes-max', str(node_pool.get('maxNumNodes', 5))]
+
+    tags = node_pool.get('tags', {})
+    if len(tags) > 0:
+        tag_list = [key + '=' + value for key, value in tags.items()]
+        args = args + ['--tags', ','.join(tag_list)]
+
+    if node_pool.get('useSpotInstances', False):
+        args = args + ['--managed', '--spot']
+
+    if len(node_pool.get('publicKeyName', '')) > 0:
+        args = args + ["--ssh-access"]
+        args = args + ['--ssh-public-key', node_pool.get('publicKeyName', '')]
+        
+    return args
+
 def get_node_pool_yaml(node_pool):
     yaml = {}
     if 'machineType' in node_pool:
@@ -30,6 +62,12 @@ def get_node_pool_yaml(node_pool):
             'publicKeyName': sshPublicKeyName,
             # Should we enable SSM??
         }
+
+    if len(node_pool.get('securityGroups', [])) > 0:
+        yaml['securityGroups'] = {
+            'attachIDs': node_pool['securityGroups']
+        }
+    yaml['privateNetworking'] = node_pool.get('privateNetworking', False)
 
     if node_pool.get('addPreBootstrapCommands', False) and not _is_none_or_blank(node_pool.get("preBootstrapCommands", "")):
         yaml['preBootstrapCommands'] = yaml.get('preBootstrapCommands', [])

--- a/python-lib/dku_utils/node_pool.py
+++ b/python-lib/dku_utils/node_pool.py
@@ -29,3 +29,38 @@ def get_node_pool_args(node_pool):
         args = args + ['--ssh-public-key', node_pool.get('publicKeyName', '')]
         
     return args
+
+def get_node_pool_yaml(node_pool):
+    yaml = {}
+    if 'machineType' in node_pool:
+        yaml['instanceType'] = node_pool['machineType']
+    if 'diskType' in node_pool:
+        yaml['volumeType'] = node_pool['diskType']
+    if 'diskSizeGb' in node_pool and node_pool['diskSizeGb'] > 0:
+        yaml['volumeSize'] = node_pool['diskSizeGb']
+    else:
+        yaml['volumeSize'] = 200 # also defined as default value in parameter-sets/node-pool-request/parameter-set.json
+
+    yaml['desiredCapacity'] = node_pool.get('numNodes', 3)
+    if node_pool.get('numNodesAutoscaling', False):
+        yaml['iam'] = {
+            'withAddOnPolicies': True
+        }
+        yaml['minSize'] = node_pool.get('minNumNodes', 2)
+        yaml['maxSize'] = node_pool.get('maxNumNodes', 2)
+
+    tags = node_pool.get('tags', {})
+    if len(tags) > 0:
+        yaml['tags'] = [ { key: value } for key, value in tags.items()]
+
+    yaml['spot'] = node_pool.get('useSpotInstances', False)
+
+    sshPublicKeyName = node_pool.get('publicKeyName', '')
+    if len(sshPublicKeyName) > 0:
+        yaml['ssh'] = {
+            'allow': True,
+            'publicKey': sshPublicKeyName,
+            # Should we enable SSM??
+        }
+        
+    return yaml

--- a/python-lib/dku_utils/node_pool.py
+++ b/python-lib/dku_utils/node_pool.py
@@ -1,3 +1,5 @@
+from dku_utils.access import _is_none_or_blank
+
 def get_node_pool_args(node_pool):
     args = []
     if 'machineType' in node_pool:
@@ -62,5 +64,8 @@ def get_node_pool_yaml(node_pool):
             'publicKey': sshPublicKeyName,
             # Should we enable SSM??
         }
-        
+
+    if node_pool.get('addPreBootstrapCommands', False) and not _is_none_or_blank(node_pool.get("preBootstrapCommands", "")):
+        node_pool['preBootstrapCommands'] = [command.strip() for command in node_pool['preBootstrapCommands'].split('\n') if len(command.strip()) > 0]
+
     return yaml

--- a/python-lib/dku_utils/node_pool.py
+++ b/python-lib/dku_utils/node_pool.py
@@ -3,7 +3,7 @@ from dku_utils.access import _is_none_or_blank
 def get_node_pool_yaml(node_pool):
     yaml = {}
     if 'machineType' in node_pool:
-        yaml['instanceType'] = node_pool.get['machineType']
+        yaml['instanceType'] = node_pool['machineType']
     yaml['volumeType'] = node_pool.get('diskType', 'gp2')
     if 'diskSizeGb' in node_pool and node_pool['diskSizeGb'] > 0:
         yaml['volumeSize'] = node_pool['diskSizeGb']

--- a/python-lib/dku_utils/node_pool.py
+++ b/python-lib/dku_utils/node_pool.py
@@ -66,7 +66,7 @@ def get_node_pool_yaml(node_pool, networking_settings):
     yaml['tags'] = node_pool.get('tags', {})
     yaml['taints'] = build_node_pool_taints_yaml(node_pool)
     node_pool['labels'] = node_pool.get('labels', {})
-    if any(node_pool['labels'].items(), lambda label: _is_none_or_blank(label[0])):
+    if any(_is_none_or_blank(label_key) for label_key in node_pool['labels'].keys()):
         raise Exception('At least one node pool label key is not valid, please ensure label keys are not empty. Observed labels: %s' % node_pool['labels'])
     yaml['labels'] = node_pool['labels']
     yaml['spot'] = node_pool.get('useSpotInstances', False)

--- a/python-lib/dku_utils/node_pool.py
+++ b/python-lib/dku_utils/node_pool.py
@@ -20,10 +20,7 @@ def get_node_pool_yaml(node_pool):
         yaml['minSize'] = node_pool.get('minNumNodes', 2)
         yaml['maxSize'] = node_pool.get('maxNumNodes', 2)
 
-    tags = node_pool.get('tags', {})
-    if len(tags) > 0:
-        yaml['tags'] = [ { key: value } for key, value in tags.items()]
-
+    yaml['tags'] = node_pool.get('tags', {})
     yaml['spot'] = node_pool.get('useSpotInstances', False)
 
     sshPublicKeyName = node_pool.get('publicKeyName', '')

--- a/python-runnables/add-node-pool/runnable.json
+++ b/python-runnables/add-node-pool/runnable.json
@@ -28,13 +28,6 @@
             "mandatory": true
         },
         {
-            "name": "nodeGroupId",
-            "label": "Node group",
-            "description": "Id of node group to create, if not default",
-            "type": "STRING",
-            "mandatory": false
-        },
-        {
             "name": "nodePool",
             "label": "Node group",
             "type": "PRESET",

--- a/python-runnables/add-node-pool/runnable.py
+++ b/python-runnables/add-node-pool/runnable.py
@@ -7,7 +7,7 @@ from dku_aws.eksctl_command import EksctlCommand
 from dku_aws.aws_command import AwsCommand
 from dku_utils.cluster import get_cluster_from_dss_cluster, get_connection_info
 from dku_utils.config_parser import get_security_groups_arg, get_region_arg
-from dku_utils.node_pool import get_node_pool_args
+from dku_utils.node_pool import get_node_pool_args, build_node_pool_taints_yaml
 from dku_utils.access import _is_none_or_blank
 
 class MyRunnable(Runnable):
@@ -74,6 +74,9 @@ class MyRunnable(Runnable):
                 for command in commands.split('\n'):
                     if len(command.strip()) > 0:
                         node_pool_dict['preBootstrapCommands'].append(command)
+
+        # Adding node pool taints on the only node pool we create which is managed:
+        yaml_dict['managedNodeGroups'][0]['taints'] = build_node_pool_taints_yaml(node_pool)
         
         yaml_loc = os.path.join(os.getcwd(), cluster_id +'_config.yaml')
         with open(yaml_loc, 'w') as outfile:

--- a/python-runnables/add-node-pool/runnable.py
+++ b/python-runnables/add-node-pool/runnable.py
@@ -34,8 +34,9 @@ class MyRunnable(Runnable):
         kube_config_path = dss_cluster_settings.get_raw()['containerSettings']['executionConfigsGenericOverrides']['kubeConfigPath']
 
         connection_info = get_connection_info(dss_cluster_config.get('config'))
-        
-        node_group_id = self.config.get('nodeGroupId', None)
+
+        node_pool = self.config.get('nodePool', {})
+        node_group_id = node_pool.get('nodeGroupId', None)
         
         # first pass: get the yaml config corresponding to the command line args
         args = ['create', 'nodegroup']
@@ -54,7 +55,6 @@ class MyRunnable(Runnable):
             
         args += get_security_groups_arg(dss_cluster_config['config'].get('networkingSettings', {}))
 
-        node_pool = self.config.get('nodePool', {})
         args += get_node_pool_args(node_pool)
 
         c = EksctlCommand(args + ["--dry-run"], connection_info)


### PR DESCRIPTION
Current EKS cluster plugin allows for the creation of a single node pool at cluster creation.
With this change, we allow users to create as many node pools as they want with different configurations.

The current implementation uses the CLI to define the node group at cluster creation. This approach does not support the creation of multiple node groups. The CLI can only take parameters for a single one.
In order to circumvent that issue, we still create the cluster definition using the `dry-run` flag, but we now do it without node groups. Then we use the node pool configuration to fill in the yaml generated by AWS for each node pool and re-run a dry-run cluster creation to fill in the boilerplate configuration of the node pools.

After that step, some extra configuration is added (already in the current implementation) and then we finally run the create cluster command for real.
<img width="928" alt="image" src="https://github.com/dataiku/dss-plugin-eks-clusters/assets/1655134/d0f53893-f1b5-474d-996e-107cef706a41">


EKS plugin also does not allow for adding labels and taints to node pools, so this PR adds that functionality at cluster creation or when adding a new node pool. ([sc-165108])
<img width="890" alt="image" src="https://github.com/dataiku/dss-plugin-eks-clusters/assets/1655134/4d909f67-a496-4c77-b3d6-ce7d849cdc18">

The Nvidia plugin version is also not the latest due to them switching release branches from master to main. This PR also includes changing the reference to the latest plugin version used for GPU loads. ([sc-171085])
This should be tested after merge by running integration tests with gpu enabled. It can be done manually by pointing the tests to this repo's master branch.

Quick note: The interface says the default disk type is `gp2` which was wrong. It was actually `gp3`. I updated the config to use `gp2` by default, but we can also just update the form to says `gp3` is the default instead.

Post merge TODO list:
- [ ] Update [guide](https://doc.dataiku.com/dss/latest/installation/cloudstacks-aws/guided-setup-new-vpc-elastic-compute.html#optional-start-your-first-elastic-compute-cluster) to include the multiple node pools
- [ ] Update MTP to create multiple node pools
- [ ] Update MTP to create labes/taints
- [ ] Review [PR to update Nvidia plugin in AKS](https://github.com/dataiku/dss-plugin-aks-clusters/pull/68)