### PR TITLE
Adding labels/taints support, allow for adding more than one node pool at cluster creation and use latest Nvidia driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
-## Version 1.3.0 - Feature release
+## Version 1.4.0 - Feature release
 - Allowing for multiple node pool definitions on cluster startup
 - Adding labels and taints support for node pools
 - Update Nvidia driver to always use the latest version
+
+## Version 1.3.1 - Bugfix release
+- Fix a bug where node pool configuration is ignored
 
 ## Version 1.2.3 - Feature and bugfix release
 - Choose autoscaler version based on the Kubernetes cluster version. For Kubernetes prior to 1.24, autoscaler version used is `v1.24.3`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next version
 - Allowing for multiple node pool definitions on cluster startup
 - Adding labels and taints support for node pools
+- Ensure latest version of Nvidia driver for GPU
 
 ## Version 1.3.2 - Bugfix release
 - Update Nvidia driver URL to new location

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Version 1.4.0 - Feature release
+## Next version
 - Allowing for multiple node pool definitions on cluster startup
 - Adding labels and taints support for node pools
 - Update Nvidia driver to always use the latest version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,9 @@
 # Changelog
 
-## Next version
+## Version 1.3.0 - Feature release
 - Allowing for multiple node pool definitions on cluster startup
 - Adding labels and taints support for node pools
 - Update Nvidia driver to always use the latest version
-
-## Version 1.3.1 - bugfix release
-- Fix a bug where node pool configuration is ignored
 
 ## Version 1.2.3 - Feature and bugfix release
 - Choose autoscaler version based on the Kubernetes cluster version. For Kubernetes prior to 1.24, autoscaler version used is `v1.24.3`

--- a/parameter-sets/node-pool-request/parameter-set.json
+++ b/parameter-sets/node-pool-request/parameter-set.json
@@ -12,6 +12,13 @@
 
     "params": [
         {
+            "name": "nodeGroupId",
+            "label": "Node group ID",
+            "description": "Id of node group to create, if not default",
+            "type": "STRING",
+            "mandatory": false
+        },
+        {
             "name": "machineType",
             "label": "Machine type",
             "description": "EC2 instance type for the nodes. See EC2 documentation for available instance types",
@@ -83,6 +90,50 @@
             "label": "Keypair name",
             "description": "Name of a keypair to use on the instances of the node group",
             "type": "STRING"
+        },
+        {
+            "name": "labels",
+            "label": "Node labels",
+            "description": "https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/",
+            "type": "MAP",
+            "mandatory": false
+        },
+        {
+            "name": "taints",
+            "label": "Node taints",
+            "description": "WARNING: MUST CREATE AT LEAST ONE NODE POOL WITHOUT TAINTS. https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/",
+            "mandatory": false,
+            "type": "OBJECT_LIST",
+            "subParams": [
+                {
+                    "type": "SEPARATOR",
+                    "label": "Enter your taints"
+                },
+                {
+                    "name": "key",
+                    "type": "STRING",
+                    "label": "Key",
+                    "mandatory": true
+                },
+                {
+                    "name": "value",
+                    "type": "STRING",
+                    "label": "Value",
+                    "mandatory": false
+                },
+                {
+                    "name": "effect",
+                    "type": "SELECT",
+                    "label": "Effect",
+                    "selectChoices": [
+                        {"value": "NoSchedule", "label": "NoSchedule"},
+                        {"value": "NoExecute", "label": "NoExecute"},
+                        {"value": "PreferNoSchedule", "label": "PreferNoSchedule"}
+                    ],
+                    "mandatory": true,
+                    "defaultValue": "NoSchedule"
+                }
+            ]
         },
         {
             "name": "enableGPU",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "eks-clusters",
-    "version": "1.3.1",
+    "version": "1.3.0",
     "meta": {
         "label": "EKS clusters",
         "description": "Interact with Amazon Elastic Kubernetes Service clusters",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "eks-clusters",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "meta": {
         "label": "EKS clusters",
         "description": "Interact with Amazon Elastic Kubernetes Service clusters",

--- a/python-clusters/create-eks-cluster/cluster.json
+++ b/python-clusters/create-eks-cluster/cluster.json
@@ -41,9 +41,9 @@
             "label": "Cluster nodes"
         },
         {
-            "name": "nodePool",
-            "label": "Initial node pool",
-            "type": "PRESET",
+            "name": "nodePools",
+            "label": "Node pools",
+            "type": "PRESETS",
             "parameterSetId" : "node-pool-request",
             "mandatory" : false
         },

--- a/python-clusters/create-eks-cluster/cluster.json
+++ b/python-clusters/create-eks-cluster/cluster.json
@@ -41,8 +41,15 @@
             "label": "Cluster nodes"
         },
         {
+            "name": "nodePool",
+            "label": "Initial node pool",
+            "type": "PRESET",
+            "parameterSetId" : "node-pool-request",
+            "mandatory" : true
+        },
+        {
             "name": "nodePools",
-            "label": "Node pools",
+            "label": "Additional node pools",
             "type": "PRESETS",
             "parameterSetId" : "node-pool-request",
             "mandatory" : false

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -7,12 +7,13 @@ from dku_aws.eksctl_command import EksctlCommand
 from dku_aws.aws_command import AwsCommand
 from dku_kube.kubeconfig import setup_creds_env
 from dku_kube.autoscaler import add_autoscaler_if_needed
-from dku_kube.gpu_driver import add_gpu_driver_if_needed, TolerationOrTaint
+from dku_kube.gpu_driver import add_gpu_driver_if_needed
 from dku_kube.metrics_server import install_metrics_server
 from dku_utils.cluster import make_overrides, get_connection_info
 from dku_utils.access import _is_none_or_blank
 from dku_utils.config_parser import get_region_arg, get_private_ip_from_metadata
 from dku_utils.node_pool import get_node_pool_yaml
+from dku_utils.taints import Taint
 
 class MyCluster(Cluster):
     def __init__(self, cluster_id, cluster_name, config, plugin_config, global_settings):
@@ -102,7 +103,7 @@ class MyCluster(Cluster):
                         if node_pool.get('enableGPU', False) or node_pool.get('numNodesAutoscaling'):
                             current_node_pool_taints = yaml_node_pool.get('taints', [])
                             for taint in current_node_pool_taints:
-                                new_taint = TolerationOrTaint(taint)
+                                new_taint = Taint(taint)
                                 if node_pool.get('enableGPU', False):
                                     gpu_node_pools_taints.add(new_taint)
                                 else:

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -7,7 +7,7 @@ from dku_aws.eksctl_command import EksctlCommand
 from dku_aws.aws_command import AwsCommand
 from dku_kube.kubeconfig import setup_creds_env
 from dku_kube.autoscaler import add_autoscaler_if_needed
-from dku_kube.gpu_driver import add_gpu_driver_if_needed
+from dku_kube.gpu_driver import add_gpu_driver_if_needed, TolerationOrTaint
 from dku_kube.metrics_server import install_metrics_server
 from dku_utils.cluster import make_overrides, get_connection_info
 from dku_utils.access import _is_none_or_blank
@@ -101,8 +101,9 @@ class MyCluster(Cluster):
                         if node_pool.get('enableGPU', False):
                             current_gpu_node_pool_taints = yaml_node_pool.get('taints', [])
                             for taint in current_gpu_node_pool_taints:
-                                if taint not in gpu_node_pools_taints:
-                                    gpu_node_pools_taints.add(taint)
+                                new_taint = TolerationOrTaint(taint)
+                                if new_taint not in gpu_node_pools_taints:
+                                    gpu_node_pools_taints.add(new_taint)
 
                 yaml_node_pool_loc = os.path.join(os.getcwd(), self.cluster_id +'_config_with_node_pools.yaml')
                 with open(yaml_node_pool_loc, 'w') as outfile:

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -28,7 +28,6 @@ class MyCluster(Cluster):
         networking_settings = self.config["networkingSettings"]
 
         has_autoscaling = False
-        has_gpu = False
         
         attach_vm_to_security_groups = False
         injected_security_group = self.config.get('injectedSG', '').strip()
@@ -47,7 +46,7 @@ class MyCluster(Cluster):
             node_pool = self.config.get('nodePool', {})
 
             if node_pool:
-                node_pools += node_pool
+                node_pools.append(node_pool)
 
             if not node_pools:
                 raise Exception("At least one node pool must be defined.")

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -44,6 +44,13 @@ class MyCluster(Cluster):
 
         else:
             node_pools = self.config.get('nodePools', [])
+            node_pool = self.config.get('nodePool', {})
+
+            if node_pool:
+                node_pools += node_pool
+
+            if not node_pools:
+                raise Exception("At least one node pool must be defined.")
 
             has_autoscaling = any(node_pool.get('numNodesAutoscaling', False) for node_pool in node_pools)
             has_gpu = any(node_pool.get('enableGPU', False) for node_pool in node_pools)

--- a/python-lib/dku_kube/autoscaler.py
+++ b/python-lib/dku_kube/autoscaler.py
@@ -56,7 +56,7 @@ def add_autoscaler_if_needed(cluster_id, cluster_config, cluster_def, kube_confi
 
     # Patch the autoscaler with the tolerations derived from node group(s) taints if any
     if tolerations:
-        autoscaler_config['spec']['template']['spec']['tolerations'] = Toleration.to_dict(tolerations)
+        autoscaler_config['spec']['template']['spec']['tolerations'] = Toleration.to_list(tolerations)
         logging.debug('Autoscaler deployment config: %s' % yaml.safe_dump(autoscaler_config, default_flow_style=False))
 
     autoscaler_full_config.append(autoscaler_config)

--- a/python-lib/dku_kube/gpu_driver.py
+++ b/python-lib/dku_kube/gpu_driver.py
@@ -56,10 +56,3 @@ def add_gpu_driver_if_needed(cluster_id, kube_config_path, connection_info, tain
     env = os.environ.copy()
     env['KUBECONFIG'] = kube_config_path
     run_with_timeout(cmd, env=env, timeout=5)
-        
-def check_eksctl_version(connection_info):
-    args = ['version']
-    c = EksctlCommand(args, connection_info)
-    o = c.run_and_get_output()
-    
-    return o >= '0.32.0'

--- a/python-lib/dku_kube/gpu_driver.py
+++ b/python-lib/dku_kube/gpu_driver.py
@@ -1,6 +1,7 @@
 import os, json, logging, requests, yaml
 
 from dku_aws.eksctl_command import EksctlCommand
+from dku_utils.access import _is_none_or_blank
 from .kubectl_command import run_with_timeout
 
 def has_gpu_driver(kube_config_path):
@@ -12,34 +13,42 @@ def has_gpu_driver(kube_config_path):
     return len(out.strip()) > 0
 
 def add_gpu_driver_if_needed(cluster_id, kube_config_path, connection_info, taints):
-    if not has_gpu_driver(kube_config_path) and not check_eksctl_version(connection_info):
-        nvidia_config_raw = requests.get('https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/main/nvidia-device-plugin.yml').text
-    else:
-        cmd = ['kubectl', 'describe', 'daemonset']
-        nvidia_config_raw, err = run_with_timeout(cmd, env=env, timeout=5)
-
-    local_nvidia_plugin_config = os.path.join(os.environ["DIP_HOME"], 'clusters', cluster_id, 'nvidia-device-plugin.yml')
+    # Get the Nvidia driver plugin configuration from the repository
+    nvidia_config_raw = requests.get('https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/main/nvidia-device-plugin.yml').text
     nvidia_config = yaml.safe_load(nvidia_config_raw)
+    tolerations = set()
 
-    if taints and nvidia_config.get('spec', {}) and nvidia_config['spec'].get('template', {}) and nvidia_config['spec']['template'].get('spec', {}):
-        tolerations = nvidia_config['spec']['template']['spec'].get('tolerations', [])
+    # Get any tolerations from the plugin configuration
+    if nvidia_config.get('spec', {}) and nvidia_config['spec'].get('template', {}) and nvidia_config['spec']['template'].get('spec', {}):
+        tolerations = set(nvidia_config['spec']['template']['spec']['tolerations'])
 
-        # If there are any taints to patch the daemonset with,
-        # We add them to the GPU plugin configuration before updating with another `kubectl apply`
-        for taint in taints:
-            # Add the relevant toleration operator
-            if taint.get('value', ''):
-                taint['operator'] = 'Equal'
-            else:
-                taint['operator'] = 'Exists'
+    # Retrieve the tolerations on the daemonset currently deployed to the cluster.
+    if has_gpu_driver(kube_config_path):
+        cmd = ['kubectl', 'get', 'daemonset', 'nvidia-device-plugin-daemonset', '-n', 'kube-system', '-o', 'jsonpath="{.spec.template.spec.tolerations}"']
+        tolerations_raw, err = run_with_timeout(cmd, env=env, timeout=5)
+        if _is_none_or_blank(tolerations_raw):
+            tolerations = tolerations.update(json.loads(tolerations_raw))
 
-            # If the toleration is not in the list, add it
-            if taint in tolerations:
-                tolerations.append(taint)
+    # If there are any taints to patch the daemonset with in the node group(s) to create,
+    # we add them to the GPU plugin configuration before updating with another `kubectl apply`
+    for taint in taints or []:
+        # Add the relevant toleration operator
+        if taint.get('value', ''):
+            taint['operator'] = 'Equal'
+        else:
+            taint['operator'] = 'Exists'
 
+        # If the toleration is not in the set, add it
+        if taint not in tolerations:
+            tolerations.add(taint)
+    nvidia_config['spec']['template']['spec']['tolerations'] = list(tolerations)
+
+    # Write the configuration locally
+    local_nvidia_plugin_config = os.path.join(os.environ["DIP_HOME"], 'clusters', cluster_id, 'nvidia-device-plugin.yml')
     with open(local_nvidia_plugin_config, "w") as f:
         yaml.safe_dump(nvidia_config, f)
 
+    # Apply the patched Nvidia driver configuration to the cluster
     cmd = ['kubectl', 'apply', '-f', local_nvidia_plugin_config]
     logging.info('Running command to install Nvidia drivers: %s', ' '.join(cmd))
     logging.info('NVIDIA GPU driver config: %s' % yaml.safe_dump(nvidia_config, default_flow_style=False))

--- a/python-lib/dku_kube/gpu_driver.py
+++ b/python-lib/dku_kube/gpu_driver.py
@@ -13,7 +13,7 @@ def has_gpu_driver(kube_config_path):
 
 def add_gpu_driver_if_needed(cluster_id, kube_config_path, connection_info):
     if not has_gpu_driver(kube_config_path) and not check_eksctl_version(connection_info):
-        cmd = ['kubectl', 'apply', '-f', "https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/master/nvidia-device-plugin.yml"]
+        cmd = ['kubectl', 'apply', '-f', "https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/main/nvidia-device-plugin.yml"]
 
         logging.info("Install NVIDIA GPU drivers with : %s" % json.dumps(cmd))
         env = os.environ.copy()

--- a/python-lib/dku_kube/gpu_driver.py
+++ b/python-lib/dku_kube/gpu_driver.py
@@ -3,6 +3,7 @@ import os, json, logging, requests, yaml
 from dku_aws.eksctl_command import EksctlCommand
 from dku_utils.access import _is_none_or_blank
 from .kubectl_command import run_with_timeout
+from dku_utils.taints import Toleration
 
 def has_gpu_driver(kube_config_path):
     env = os.environ.copy()
@@ -20,32 +21,22 @@ def add_gpu_driver_if_needed(cluster_id, kube_config_path, connection_info, tain
 
     # Get any tolerations from the plugin configuration
     if nvidia_config.get('spec', {}) and nvidia_config['spec'].get('template', {}) and nvidia_config['spec']['template'].get('spec', {}):
-        tolerations.update([TolerationOrTaint(tol) for tol in nvidia_config['spec']['template']['spec']['tolerations']])
+        tolerations.update(Toleration.from_dict(nvidia_config['spec']['template']['spec']['tolerations']))
 
     # Retrieve the tolerations on the daemonset currently deployed to the cluster.
     if has_gpu_driver(kube_config_path):
         cmd = ['kubectl', 'get', 'daemonset', 'nvidia-device-plugin-daemonset', '-n', 'kube-system', '-o', 'jsonpath="{.spec.template.spec.tolerations}"']
-        tolerations_raw, err = run_with_timeout(cmd, env=env, timeout=5)
-        if _is_none_or_blank(tolerations_raw):
-            tolerations.update([TolerationOrTaint(tol) for tol in json.loads(tolerations_raw)])
+        tolerations_json, err = run_with_timeout(cmd, env=env, timeout=5)
+        if _is_none_or_blank(tolerations_json):
+            tolerations.update(Toleration.from_json(tolerations_json))
 
     # If there are any taints to patch the daemonset with in the node group(s) to create,
     # we add them to the GPU plugin configuration before updating with another `kubectl apply`
-    for taint in taints or []:
-        # Add the relevant toleration operator
-        if taint.get('value', ''):
-            taint['operator'] = 'Equal'
-        else:
-            taint['operator'] = 'Exists'
-
-        # If the toleration is not in the set, add it
-        new_toleration = TolerationOrTaint(taint)
-        if not tolerations or new_toleration not in tolerations:
-            tolerations.add(new_toleration)
+    tolerations.update(Toleration.from_dict(taints))
     
     # Patch the Nvidia driver configuration with the tolerations derived from node group(s) taints,
     # initial Nvidia driver configuration tolerations and Nvidia daemonset tolerations (when applicable)
-    nvidia_config['spec']['template']['spec']['tolerations'] = [toleration.to_dict() for toleration in tolerations]
+    nvidia_config['spec']['template']['spec']['tolerations'] = Toleration.to_dict(tolerations)
 
     # Write the configuration locally
     local_nvidia_plugin_config = os.path.join(os.environ["DIP_HOME"], 'clusters', cluster_id, 'nvidia-device-plugin.yml')
@@ -60,29 +51,3 @@ def add_gpu_driver_if_needed(cluster_id, kube_config_path, connection_info, tain
     env = os.environ.copy()
     env['KUBECONFIG'] = kube_config_path
     run_with_timeout(cmd, env=env, timeout=5)
-
-class TolerationOrTaint(dict):
-    def __init__(self, tolerationOrTaint):
-        if not _is_none_or_blank(tolerationOrTaint.get('key', '')):
-            self['key'] = tolerationOrTaint.get('key', '')
-
-        if not _is_none_or_blank(tolerationOrTaint.get('value', '')):
-            self['value'] = tolerationOrTaint.get('value', '')
-
-        if not _is_none_or_blank(tolerationOrTaint.get('effect', '')):
-            self['effect'] = tolerationOrTaint.get('effect', '')
-
-        if not _is_none_or_blank(tolerationOrTaint.get('operator', '')):
-            self['operator'] = tolerationOrTaint.get('operator', '')
-
-    def __eq__(self, other):
-        return self.get('key', '') == other.get('key', '') and self.get('value', '') == other.get('value', '') and self.get('effect', '') == other.get('effect', '') and self.get('operator', '') == other.get('operator', '')
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
-    def __hash__(self):
-        return hash((self.get('key', ''), self.get('value', ''), self.get('effect', ''), self.get('operator', '')))
-    
-    def to_dict(self):
-        return {k: v for k, v in self.items()}

--- a/python-lib/dku_kube/gpu_driver.py
+++ b/python-lib/dku_kube/gpu_driver.py
@@ -36,7 +36,7 @@ def add_gpu_driver_if_needed(cluster_id, kube_config_path, connection_info, tain
     
     # Patch the Nvidia driver configuration with the tolerations derived from node group(s) taints,
     # initial Nvidia driver configuration tolerations and Nvidia daemonset tolerations (when applicable)
-    nvidia_config['spec']['template']['spec']['tolerations'] = Toleration.to_dict(tolerations)
+    nvidia_config['spec']['template']['spec']['tolerations'] = Toleration.to_list(tolerations)
 
     # Write the configuration locally
     local_nvidia_plugin_config = os.path.join(os.environ["DIP_HOME"], 'clusters', cluster_id, 'nvidia-device-plugin.yml')

--- a/python-lib/dku_kube/gpu_driver.py
+++ b/python-lib/dku_kube/gpu_driver.py
@@ -20,14 +20,14 @@ def add_gpu_driver_if_needed(cluster_id, kube_config_path, connection_info, tain
 
     # Get any tolerations from the plugin configuration
     if nvidia_config.get('spec', {}) and nvidia_config['spec'].get('template', {}) and nvidia_config['spec']['template'].get('spec', {}):
-        tolerations = set(nvidia_config['spec']['template']['spec']['tolerations'])
+        tolerations.update([TolerationOrTaint(tol) for tol in nvidia_config['spec']['template']['spec']['tolerations']])
 
     # Retrieve the tolerations on the daemonset currently deployed to the cluster.
     if has_gpu_driver(kube_config_path):
         cmd = ['kubectl', 'get', 'daemonset', 'nvidia-device-plugin-daemonset', '-n', 'kube-system', '-o', 'jsonpath="{.spec.template.spec.tolerations}"']
         tolerations_raw, err = run_with_timeout(cmd, env=env, timeout=5)
         if _is_none_or_blank(tolerations_raw):
-            tolerations = tolerations.update(json.loads(tolerations_raw))
+            tolerations.update([TolerationOrTaint(tol) for tol in json.loads(tolerations_raw)])
 
     # If there are any taints to patch the daemonset with in the node group(s) to create,
     # we add them to the GPU plugin configuration before updating with another `kubectl apply`
@@ -39,9 +39,13 @@ def add_gpu_driver_if_needed(cluster_id, kube_config_path, connection_info, tain
             taint['operator'] = 'Exists'
 
         # If the toleration is not in the set, add it
-        if taint not in tolerations:
-            tolerations.add(taint)
-    nvidia_config['spec']['template']['spec']['tolerations'] = list(tolerations)
+        new_toleration = TolerationOrTaint(taint)
+        if not tolerations or new_toleration not in tolerations:
+            tolerations.add(new_toleration)
+    
+    # Patch the Nvidia driver configuration with the tolerations derived from node group(s) taints,
+    # initial Nvidia driver configuration tolerations and Nvidia daemonset tolerations (when applicable)
+    nvidia_config['spec']['template']['spec']['tolerations'] = [toleration.to_dict() for toleration in tolerations]
 
     # Write the configuration locally
     local_nvidia_plugin_config = os.path.join(os.environ["DIP_HOME"], 'clusters', cluster_id, 'nvidia-device-plugin.yml')
@@ -56,3 +60,29 @@ def add_gpu_driver_if_needed(cluster_id, kube_config_path, connection_info, tain
     env = os.environ.copy()
     env['KUBECONFIG'] = kube_config_path
     run_with_timeout(cmd, env=env, timeout=5)
+
+class TolerationOrTaint(dict):
+    def __init__(self, tolerationOrTaint):
+        if not _is_none_or_blank(tolerationOrTaint.get('key', '')):
+            self['key'] = tolerationOrTaint.get('key', '')
+
+        if not _is_none_or_blank(tolerationOrTaint.get('value', '')):
+            self['value'] = tolerationOrTaint.get('value', '')
+
+        if not _is_none_or_blank(tolerationOrTaint.get('effect', '')):
+            self['effect'] = tolerationOrTaint.get('effect', '')
+
+        if not _is_none_or_blank(tolerationOrTaint.get('operator', '')):
+            self['operator'] = tolerationOrTaint.get('operator', '')
+
+    def __eq__(self, other):
+        return self.get('key', '') == other.get('key', '') and self.get('value', '') == other.get('value', '') and self.get('effect', '') == other.get('effect', '') and self.get('operator', '') == other.get('operator', '')
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash((self.get('key', ''), self.get('value', ''), self.get('effect', ''), self.get('operator', '')))
+    
+    def to_dict(self):
+        return {k: v for k, v in self.items()}

--- a/python-lib/dku_kube/gpu_driver.py
+++ b/python-lib/dku_kube/gpu_driver.py
@@ -1,4 +1,4 @@
-import os, json, logging
+import os, json, logging, requests, yaml
 
 from dku_aws.eksctl_command import EksctlCommand
 from .kubectl_command import run_with_timeout
@@ -7,22 +7,50 @@ def has_gpu_driver(kube_config_path):
     env = os.environ.copy()
     env['KUBECONFIG'] = kube_config_path
     cmd = ['kubectl', 'get', 'pods', '--namespace', 'kube-system', '-l', 'name=nvidia-device-plugin-ds', '--ignore-not-found']
-    logging.info("Checking if NVIDIA GPU drivers are installed with : %s" % json.dumps(cmd))
+    logging.info('Checking if NVIDIA GPU drivers are installed with : %s' % json.dumps(cmd))
     out, err = run_with_timeout(cmd, env=env, timeout=5)
     return len(out.strip()) > 0
 
-def add_gpu_driver_if_needed(cluster_id, kube_config_path, connection_info):
+def add_gpu_driver_if_needed(cluster_id, kube_config_path, connection_info, taints):
     if not has_gpu_driver(kube_config_path) and not check_eksctl_version(connection_info):
-        cmd = ['kubectl', 'apply', '-f', "https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/main/nvidia-device-plugin.yml"]
+        nvidia_config_raw = requests.get('https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/main/nvidia-device-plugin.yml').text
+    else:
+        cmd = ['kubectl', 'describe', 'daemonset']
+        nvidia_config_raw, err = run_with_timeout(cmd, env=env, timeout=5)
 
-        logging.info("Install NVIDIA GPU drivers with : %s" % json.dumps(cmd))
-        env = os.environ.copy()
-        env['KUBECONFIG'] = kube_config_path
-        run_with_timeout(cmd, env=env, timeout=5)
+    local_nvidia_plugin_config = os.path.join(os.environ["DIP_HOME"], 'clusters', cluster_id, 'nvidia-device-plugin.yml')
+    nvidia_config = yaml.safe_load(nvidia_config_raw)
+
+    if taints and nvidia_config.get('spec', {}) and nvidia_config['spec'].get('template', {}) and nvidia_config['spec']['template'].get('spec', {}):
+        tolerations = nvidia_config['spec']['template']['spec'].get('tolerations', [])
+
+        # If there are any taints to patch the daemonset with,
+        # We add them to the GPU plugin configuration before updating with another `kubectl apply`
+        for taint in taints:
+            # Add the relevant toleration operator
+            if taint.get('value', ''):
+                taint['operator'] = 'Equal'
+            else:
+                taint['operator'] = 'Exists'
+
+            # If the toleration is not in the list, add it
+            if taint in tolerations:
+                tolerations.append(taint)
+
+    with open(local_nvidia_plugin_config, "w") as f:
+        yaml.safe_dump(nvidia_config, f)
+
+    cmd = ['kubectl', 'apply', '-f', local_nvidia_plugin_config]
+    logging.info('Running command to install Nvidia drivers: %s', ' '.join(cmd))
+    logging.info('NVIDIA GPU driver config: %s' % yaml.safe_dump(nvidia_config, default_flow_style=False))
+
+    env = os.environ.copy()
+    env['KUBECONFIG'] = kube_config_path
+    run_with_timeout(cmd, env=env, timeout=5)
         
 def check_eksctl_version(connection_info):
-    args = ["version"]
+    args = ['version']
     c = EksctlCommand(args, connection_info)
     o = c.run_and_get_output()
     
-    return o >= "0.32.0"
+    return o >= '0.32.0'

--- a/python-lib/dku_utils/node_pool.py
+++ b/python-lib/dku_utils/node_pool.py
@@ -1,3 +1,6 @@
+import logging
+from dku_utils.access import _is_none_or_blank
+
 def get_node_pool_args(node_pool):
     args = []
     if 'machineType' in node_pool:
@@ -17,15 +20,98 @@ def get_node_pool_args(node_pool):
         args = args + ['--nodes-max', str(node_pool.get('maxNumNodes', 5))]
 
     tags = node_pool.get('tags', {})
-    if len(tags) > 0:
+    if tags:
         tag_list = [key + '=' + value for key, value in tags.items()]
         args = args + ['--tags', ','.join(tag_list)]
 
     if node_pool.get('useSpotInstances', False):
         args = args + ['--managed', '--spot']
 
-    if len(node_pool.get('publicKeyName', '')) > 0:
-        args = args + ["--ssh-access"]
+    if node_pool.get('publicKeyName', ''):
+        args = args + ['--ssh-access']
         args = args + ['--ssh-public-key', node_pool.get('publicKeyName', '')]
-        
+
+    node_pool['labels'] = node_pool.get('labels', {})
+    if node_pool['labels']:
+        labels = []
+        for label_key, label_value in node_pool['labels'].items():
+            if not label_key:
+                logging.error('At least one node pool label key is not valid, please ensure label keys are not empty. Observed labels: %s' % node_pool['labels'])
+                raise Exception('At least one node pool label key is not valid, please ensure label keys are not empty. Observed labels: %s' % node_pool['labels'])
+            if not label_value:
+                label_value = ''
+            labels.append('%s=%s' % (label_key, label_value))
+        args += ['--node-labels', ','.join(labels)]
+
     return args
+
+def get_node_pool_yaml(node_pool, networking_settings):
+    yaml = {
+        'iam': {
+            'withAddonPolicies': {
+                'imageBuilder': True # Adding full ECR access to the node group
+            }
+        }
+    }
+    if 'machineType' in node_pool:
+        yaml['instanceType'] = node_pool['machineType']
+
+    if 'diskType' in node_pool:
+        yaml['volumeType'] = node_pool['diskType']
+
+    if 'diskSizeGb' in node_pool and node_pool['diskSizeGb'] > 0:
+        yaml['volumeSize'] = node_pool['diskSizeGb']
+    else:
+        yaml['volumeSize'] = 200 # also defined as default value in parameter-sets/node-pool-request/parameter-set.json
+
+    yaml['desiredCapacity'] = node_pool.get('numNodes', 3)
+    if node_pool.get('numNodesAutoscaling', False):
+        yaml['iam']['withAddonPolicies']['autoScaler'] = True
+        yaml['minSize'] = node_pool.get('minNumNodes', 2)
+        yaml['maxSize'] = node_pool.get('maxNumNodes', 5)
+
+    yaml['tags'] = node_pool.get('tags', {})
+    yaml['taints'] = build_node_pool_taints_yaml(node_pool)
+    node_pool['labels'] = node_pool.get('labels', {})
+    if any(_is_none_or_blank(label_key) for label_key in node_pool['labels'].keys()):
+        logging.error('At least one node pool label key is not valid, please ensure label keys are not empty. Observed labels: [%s]' % ';'.join(node_pool['labels']))
+        raise Exception('At least one node pool label key is not valid, please ensure label keys are not empty. Observed labels: [%s]' % ';'.join(node_pool['labels']))
+    yaml['labels'] = node_pool['labels']
+    yaml['spot'] = node_pool.get('useSpotInstances', False)
+
+    sshPublicKeyName = node_pool.get('publicKeyName', '')
+    if not _is_none_or_blank(sshPublicKeyName):
+        yaml['ssh'] = {
+            'allow': True,
+            'publicKeyName': sshPublicKeyName
+        }
+
+    if networking_settings.get('securityGroups', []):
+        yaml['securityGroups'] = {
+            'attachIDs': list(map(lambda security_group: security_group.strip(), networking_settings['securityGroups']))
+        }
+    yaml['privateNetworking'] = networking_settings.get('privateNetworking', False)
+
+    if node_pool.get('addPreBootstrapCommands', False) and not _is_none_or_blank(node_pool.get('preBootstrapCommands', '')):
+        yaml['preBootstrapCommands'] = yaml.get('preBootstrapCommands', [])
+        yaml['preBootstrapCommands'] += [command.strip()\
+                                          for command in node_pool['preBootstrapCommands'].split('\n')\
+                                              if not _is_none_or_blank(command.strip())]
+
+    return yaml
+
+def build_node_pool_taints_yaml(node_pool):
+    node_pool['taints'] = node_pool.get('taints', [])
+    yaml_taints = []
+    if node_pool['taints']:
+        for taint in node_pool['taints']:
+            if not _is_none_or_blank(taint.get('key', '')):
+                yaml_taints.append({
+                    'key': taint['key'],
+                    'value': taint.get('value', ''),
+                    'effect': taint.get('effect', 'NoSchedule')
+                })
+            else:
+                logging.error('A node pool taint is invalid, please ensure that the key to a taint is not empty. Observed taints: [%s]' % ';'.join(node_pool['taints']))
+                raise Exception('A node pool taint is invalid, please ensure that the key to a taint is not empty. Observed taints: [%s]' % ';'.join(node_pool['taints']))
+    return yaml_taints

--- a/python-lib/dku_utils/node_pool.py
+++ b/python-lib/dku_utils/node_pool.py
@@ -69,6 +69,7 @@ def get_node_pool_yaml(node_pool, networking_settings):
         yaml['iam']['withAddonPolicies']['autoScaler'] = True
         yaml['minSize'] = node_pool.get('minNumNodes', 2)
         yaml['maxSize'] = node_pool.get('maxNumNodes', 5)
+        yaml['propagateASGTags'] = True
 
     yaml['tags'] = node_pool.get('tags', {})
     yaml['taints'] = build_node_pool_taints_yaml(node_pool)

--- a/python-lib/dku_utils/taints.py
+++ b/python-lib/dku_utils/taints.py
@@ -49,5 +49,5 @@ class Toleration(Taint):
         return [Toleration(raw) for raw in raw_dicts or []]
 
     @staticmethod
-    def to_dict(tolerations):
+    def to_list(tolerations):
         return [toleration.to_dict() for toleration in tolerations]

--- a/python-lib/dku_utils/taints.py
+++ b/python-lib/dku_utils/taints.py
@@ -1,0 +1,53 @@
+import json
+from dku_utils.access import _is_none_or_blank
+
+class Taint(dict):
+    def __init__(self, taint):
+        if not _is_none_or_blank(taint.get('key', '')):
+            self['key'] = taint.get('key', '')
+
+        if not _is_none_or_blank(taint.get('value', '')):
+            self['value'] = taint.get('value', '')
+
+        if not _is_none_or_blank(taint.get('effect', '')):
+            self['effect'] = taint.get('effect', '')
+
+    def __eq__(self, other):
+        return self.get('key', '') == other.get('key', '') and self.get('value', '') == other.get('value', '') and self.get('effect', '') == other.get('effect', '')
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash((self.get('key', ''), self.get('value', ''), self.get('effect', '')))
+
+class Toleration(Taint):
+    def __init__(self, taint):
+        super().__init__(taint)
+
+        if self.get('value', ''):
+            self['operator'] = 'Equal'
+        else:
+            self['operator'] = 'Exists'
+
+    def __eq__(self, other):
+        return super().__eq__(other) and self.get('operator', '') == other.get('operator', '')
+
+
+    def __hash__(self):
+        return hash((super().__hash__(), self.get('operator', '')))
+
+    def to_dict(self):
+        return {k: v for k, v in self.items()}
+    
+    @staticmethod
+    def from_json(tolerations_json):
+        return [Toleration(tol) for tol in json.loads(tolerations_json)]
+
+    @staticmethod
+    def from_dict(raw_dicts):
+        return [Toleration(raw) for raw in raw_dicts or []]
+
+    @staticmethod
+    def to_dict(tolerations):
+        return [toleration.to_dict() for toleration in tolerations]

--- a/python-runnables/add-autoscaler/runnable.py
+++ b/python-runnables/add-autoscaler/runnable.py
@@ -30,5 +30,5 @@ class MyRunnable(Runnable):
         if has_autoscaler(kube_config_path):
             return '<h5>An autoscaler pod already runs<h5>'
         else:
-            add_autoscaler_if_needed(cluster_id, self.config, cluster_def, kube_config_path)
+            add_autoscaler_if_needed(cluster_id, self.config, cluster_def, kube_config_path, [])
             return '<h5>Created an autoscaler pod<h5>'

--- a/python-runnables/add-node-pool/runnable.json
+++ b/python-runnables/add-node-pool/runnable.json
@@ -28,13 +28,6 @@
             "mandatory": true
         },
         {
-            "name": "nodeGroupId",
-            "label": "Node group",
-            "description": "Id of node group to create, if not default",
-            "type": "STRING",
-            "mandatory": false
-        },
-        {
             "name": "nodePool",
             "label": "Node group",
             "type": "PRESET",

--- a/python-runnables/add-node-pool/runnable.py
+++ b/python-runnables/add-node-pool/runnable.py
@@ -94,7 +94,7 @@ class MyRunnable(Runnable):
         
         if node_pool.get('numNodesAutoscaling', False):
             logging.info("Nodegroup is autoscaling, ensuring autoscaler")
-            add_autoscaler_if_needed(cluster_id, self.config, cluster_data.get("cluster"), kube_config_path)
+            add_autoscaler_if_needed(cluster_id, self.config, cluster_data.get("cluster"), kube_config_path, node_group_taints)
             
         if node_pool.get('enableGPU', False):
             logging.info("Nodegroup is GPU-enabled, ensuring NVIDIA GPU Drivers")

--- a/python-runnables/add-node-pool/runnable.py
+++ b/python-runnables/add-node-pool/runnable.py
@@ -7,7 +7,7 @@ from dku_aws.eksctl_command import EksctlCommand
 from dku_aws.aws_command import AwsCommand
 from dku_utils.cluster import get_cluster_from_dss_cluster, get_connection_info
 from dku_utils.config_parser import get_security_groups_arg, get_region_arg
-from dku_utils.node_pool import get_node_pool_args
+from dku_utils.node_pool import get_node_pool_args, build_node_pool_taints_yaml
 from dku_utils.access import _is_none_or_blank
 
 class MyRunnable(Runnable):
@@ -34,8 +34,9 @@ class MyRunnable(Runnable):
         kube_config_path = dss_cluster_settings.get_raw()['containerSettings']['executionConfigsGenericOverrides']['kubeConfigPath']
 
         connection_info = get_connection_info(dss_cluster_config.get('config'))
-        
-        node_group_id = self.config.get('nodeGroupId', None)
+
+        node_pool = self.config.get('nodePool', {})
+        node_group_id = node_pool.get('nodeGroupId', None)
         
         # first pass: get the yaml config corresponding to the command line args
         args = ['create', 'nodegroup']
@@ -54,7 +55,6 @@ class MyRunnable(Runnable):
             
         args += get_security_groups_arg(dss_cluster_config['config'].get('networkingSettings', {}))
 
-        node_pool = self.config.get('nodePool', {})
         args += get_node_pool_args(node_pool)
 
         c = EksctlCommand(args + ["--dry-run"], connection_info)
@@ -74,6 +74,9 @@ class MyRunnable(Runnable):
                 for command in commands.split('\n'):
                     if len(command.strip()) > 0:
                         node_pool_dict['preBootstrapCommands'].append(command)
+
+        # Adding node pool taints on the only node pool we create which is managed:
+        yaml_dict['managedNodeGroups'][0]['taints'] = build_node_pool_taints_yaml(node_pool)
         
         yaml_loc = os.path.join(os.getcwd(), cluster_id +'_config.yaml')
         with open(yaml_loc, 'w') as outfile:

--- a/python-runnables/add-node-pool/runnable.py
+++ b/python-runnables/add-node-pool/runnable.py
@@ -76,7 +76,8 @@ class MyRunnable(Runnable):
                         node_pool_dict['preBootstrapCommands'].append(command)
 
         # Adding node pool taints on the only node pool we create which is managed:
-        yaml_dict['managedNodeGroups'][0]['taints'] = build_node_pool_taints_yaml(node_pool)
+        node_group_taints = build_node_pool_taints_yaml(node_pool)
+        yaml_dict['managedNodeGroups'][0]['taints'] = node_group_taints
         
         yaml_loc = os.path.join(os.getcwd(), cluster_id +'_config.yaml')
         with open(yaml_loc, 'w') as outfile:
@@ -97,7 +98,7 @@ class MyRunnable(Runnable):
             
         if node_pool.get('enableGPU', False):
             logging.info("Nodegroup is GPU-enabled, ensuring NVIDIA GPU Drivers")
-            add_gpu_driver_if_needed(self.config['clusterId'], kube_config_path, connection_info)
+            add_gpu_driver_if_needed(self.config['clusterId'], kube_config_path, connection_info, node_group_taints)
 
         args = ['get', 'nodegroup']
         #args = args + ['-v', '4']

--- a/python-runnables/add-node-pool/runnable.py
+++ b/python-runnables/add-node-pool/runnable.py
@@ -78,7 +78,12 @@ class MyRunnable(Runnable):
         # Adding node pool taints on the only node pool we create which is managed:
         node_group_taints = build_node_pool_taints_yaml(node_pool)
         yaml_dict['managedNodeGroups'][0]['taints'] = node_group_taints
-        
+
+        # Adding propagateASGTags to the node group if it is autoscaled.
+        # This propagates the labels/taints of the node group to the autoscaling group so that new nodes can be properly configured on creation (scaling up)
+        if node_pool.get('numNodesAutoscaling', False):
+            yaml_dict['managedNodeGroups'][0]['propagateASGTags'] = True
+
         yaml_loc = os.path.join(os.getcwd(), cluster_id +'_config.yaml')
         with open(yaml_loc, 'w') as outfile:
             yaml.dump(yaml_dict, outfile, default_flow_style=False)


### PR DESCRIPTION
Re-introducing labels and taints support for EKS node groups, updating Nvidia driver to latest and allowing for definition of multiple node groups at cluster creation (while keeping current initial node group definition in config)

When supporting taints on node groups, we have to take into account GPU enabled groups. The Nvidia driver daemonset contains a toleration for the `nvidia.com/gpu` taint to exist on the nodes it can be applied to, but it needs to be patched for other custom taints.

Regarding taints and the autoscaler, we have to patch the autoscaler configuration with the taints of the autoscaled node pools as tolerations AND we have to add the `propagateASGTags` to the node pool configuration.
This flag will add the labels and taints of the node group to the AutoScaling Group (ASG) as tags. These tags are used to label and taint new nodes on scaling up (new nodes created).

[sc-174884]
[sc-165108]
[sc-167294]
[sc-177800]