### PR TITLE
[sc-181246] revert to previous behavior regarding no specified node pool

### DIFF
--- a/python-clusters/create-eks-cluster/cluster.json
+++ b/python-clusters/create-eks-cluster/cluster.json
@@ -45,7 +45,7 @@
             "label": "Initial node pool",
             "type": "PRESET",
             "parameterSetId" : "node-pool-request",
-            "mandatory" : true
+            "mandatory" : false
         },
         {
             "name": "nodePools",

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -53,9 +53,6 @@ class MyCluster(Cluster):
             if node_pool:
                 node_pools.append(node_pool)
 
-            if not node_pools:
-                raise Exception("At least one node pool must be defined.")
-
             has_autoscaling = any(node_pool.get('numNodesAutoscaling', False) for node_pool in node_pools)
             has_gpu = any(node_pool.get('enableGPU', False) for node_pool in node_pools)
 


### PR DESCRIPTION
Making the initial node pool mandatory would display an initial node pool with all default values from the node pool when the initial node pool value is `None`. Including:
* at cluster creation time and nothing has been configured yet
* when the cluster already exists and the initial node pool was `None` before

These default values are only displayed but not saved until the `SAVE` button is clicked (or the `START` button that first saves the current configuration)

Previous behavior: when you create a cluster with initial node pool set to `None`, due to options we add during the Python execution, it would create a node pool with 3 nodes, 200Go disks (our defaults) and `m5.large` machines (EKS default)

Going back to `mandatory: false` will enable again to display `None` value for the initial node pool in the cluster form (it was still possible to force the value to `None` but it would be needed each time the form needs to be saved)

Adding the exception when no node pool is defined would prevent the previously described behavior from happening so, now `None` is the default value for the initial node pool again and we want to go back to previous behavior, we are removing it