### PR TITLE
Fix add node pool macro when the definition contains GPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## Version 1.4.1 - Feature and bugfix release
+## Version 1.4.1 - Bugfix release
+- Fix an issue when using the action to add a node pool with GPU
+
+## Version 1.4.0 - Feature and bugfix release
 - Allowing for multiple node pool definitions on cluster startup
 - Adding labels and taints support for node pools
 - Ensure latest version of Nvidia driver for GPU

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Version 1.4.0 - Feature and bugfix release
+## Version 1.4.1 - Feature and bugfix release
 - Allowing for multiple node pool definitions on cluster startup
 - Adding labels and taints support for node pools
 - Ensure latest version of Nvidia driver for GPU

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "eks-clusters",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "meta": {
         "label": "EKS clusters",
         "description": "Interact with Amazon Elastic Kubernetes Service clusters",

--- a/python-lib/dku_kube/gpu_driver.py
+++ b/python-lib/dku_kube/gpu_driver.py
@@ -14,6 +14,9 @@ def has_gpu_driver(kube_config_path):
     return len(out.strip()) > 0
 
 def add_gpu_driver_if_needed(cluster_id, kube_config_path, connection_info, taints):
+    env = os.environ.copy()
+    env['KUBECONFIG'] = kube_config_path
+
     # Get the Nvidia driver plugin configuration from the repository
     nvidia_config_raw = requests.get('https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/main/deployments/static/nvidia-device-plugin.yml').text
     nvidia_config = yaml.safe_load(nvidia_config_raw)
@@ -48,6 +51,4 @@ def add_gpu_driver_if_needed(cluster_id, kube_config_path, connection_info, tain
     logging.info('Running command to install Nvidia drivers: %s', ' '.join(cmd))
     logging.info('NVIDIA GPU driver config: %s' % yaml.safe_dump(nvidia_config, default_flow_style=False))
 
-    env = os.environ.copy()
-    env['KUBECONFIG'] = kube_config_path
     run_with_timeout(cmd, env=env, timeout=5)


### PR DESCRIPTION
[sc-183270]

Bug fix when trying to add a node pool with GPU via the macro when the cluster already has the driver installed.