### PR TITLE
Create GitHub action to upload the latest version of the plugin to s3

### DIFF
--- a/.github/workflows/upload-plugin-s3.yml
+++ b/.github/workflows/upload-plugin-s3.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         id=$(jq -r '.id' plugin.json)
         version=$(jq -r '.version' plugin.json)
-        echo "Creating release for plugin '$id' and version '$version'"
+        echo "Upload plugin '$id' and version '$version'"
         echo "id=$id" >> $GITHUB_OUTPUT
         echo "version=$version" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/upload-plugin-s3.yml
+++ b/.github/workflows/upload-plugin-s3.yml
@@ -11,6 +11,10 @@ env:
   AWS_PLUGINBUCKET_IAM_ROLE: arn:aws:iam::236706865914:role/dss-plugin-eks-clusters-github
   AWS_REGION: eu-west-1
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   upload:
     runs-on: ubuntu-latest
@@ -37,7 +41,7 @@ jobs:
       run: make plugin
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v4.0.2
       with:
         role-to-assume: ${{ env.AWS_PLUGINBUCKET_IAM_ROLE }}
         aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/upload-plugin-s3.yml
+++ b/.github/workflows/upload-plugin-s3.yml
@@ -23,6 +23,12 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y make
+        sudo apt-get install -y jq
+
     - name: Retrieve plugin info
       id: plugin_info
       run: |
@@ -32,16 +38,11 @@ jobs:
         echo "id=$id" >> $GITHUB_OUTPUT
         echo "version=$version" >> $GITHUB_OUTPUT
 
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y make
-
     - name: Compile plugin into archive
       run: make plugin
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4.0.2
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ env.AWS_BUCKET_IAM_ROLE }}
         aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/upload-plugin-s3.yml
+++ b/.github/workflows/upload-plugin-s3.yml
@@ -7,8 +7,8 @@ on:
   workflow_dispatch:
 
 env:
-  AWS_PLUGINBUCKET_NAME: dss-plugins
-  AWS_PLUGINBUCKET_IAM_ROLE: arn:aws:iam::236706865914:role/dss-plugin-eks-clusters-github
+  AWS_BUCKET_NAME: ${{ vars.DKU_PLUGINS_S3_BUCKET }}
+  AWS_BUCKET_IAM_ROLE: ${{ vars.DKU_PLUGINS_AWS_IAM_ROLE }}
   AWS_REGION: eu-west-1
 
 permissions:
@@ -43,18 +43,18 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4.0.2
       with:
-        role-to-assume: ${{ env.AWS_PLUGINBUCKET_IAM_ROLE }}
+        role-to-assume: ${{ env.AWS_BUCKET_IAM_ROLE }}
         aws-region: ${{ env.AWS_REGION }}
 
     - name: Ensure S3 prefix exists
       run: |
-        echo "Ensuring that prefix '${{ steps.plugin_info.outputs.id }}/releases/latest' exists on '${{ env.AWS_PLUGINBUCKET_NAME }}'"
-        aws s3api put-object --bucket ${{ env.AWS_PLUGINBUCKET_NAME }} --key "${{ steps.plugin_info.outputs.id }}/releases/latest/"
+        echo "Ensuring that prefix '${{ steps.plugin_info.outputs.id }}/releases/latest' exists on '${{ env.AWS_BUCKET_NAME }}'"
+        aws s3api put-object --bucket ${{ env.AWS_BUCKET_NAME }} --key "${{ steps.plugin_info.outputs.id }}/releases/latest/"
 
     - name: Upload to S3
       run: |
-        echo "Uploading './dist/dss-plugin-${{ steps.plugin_info.outputs.id }}-${{ steps.plugin_info.outputs.version }}.zip' to 's3://${{ env.AWS_PLUGINBUCKET_NAME }}/${{ steps.plugin_info.outputs.id }}/releases/latest/dss-plugin-${{ steps.plugin_info.outputs.id }}-latest.zip'"
-        aws s3 cp ./dist/dss-plugin-${{ steps.plugin_info.outputs.id }}-${{ steps.plugin_info.outputs.version }}.zip s3://${{ env.AWS_PLUGINBUCKET_NAME }}/${{ steps.plugin_info.outputs.id }}/releases/latest/dss-plugin-${{ steps.plugin_info.outputs.id }}-latest.zip
+        echo "Uploading './dist/dss-plugin-${{ steps.plugin_info.outputs.id }}-${{ steps.plugin_info.outputs.version }}.zip' to 's3://${{ env.AWS_BUCKET_NAME }}/${{ steps.plugin_info.outputs.id }}/releases/latest/dss-plugin-${{ steps.plugin_info.outputs.id }}-latest.zip'"
+        aws s3 cp ./dist/dss-plugin-${{ steps.plugin_info.outputs.id }}-${{ steps.plugin_info.outputs.version }}.zip s3://${{ env.AWS_BUCKET_NAME }}/${{ steps.plugin_info.outputs.id }}/releases/latest/dss-plugin-${{ steps.plugin_info.outputs.id }}-latest.zip
 
     - name: Clean up release assets
       run: make dist-clean

--- a/.github/workflows/upload-plugin-s3.yml
+++ b/.github/workflows/upload-plugin-s3.yml
@@ -1,0 +1,56 @@
+name: Upload latest plugin to S3
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+env:
+  AWS_PLUGINBUCKET_NAME: dss-plugins
+  AWS_PLUGINBUCKET_IAM_ROLE: arn:aws:iam::236706865914:role/dss-plugin-eks-clusters-github
+  AWS_REGION: eu-west-1
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Retrieve plugin info
+      id: plugin_info
+      run: |
+        id=$(jq -r '.id' plugin.json)
+        version=$(jq -r '.version' plugin.json)
+        echo "Creating release for plugin '$id' and version '$version'"
+        echo "id=$id" >> $GITHUB_OUTPUT
+        echo "version=$version" >> $GITHUB_OUTPUT
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y make
+
+    - name: Compile plugin into archive
+      run: make plugin
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        role-to-assume: ${{ env.AWS_PLUGINBUCKET_IAM_ROLE }}
+        aws-region: ${{ env.AWS_REGION }}
+
+    - name: Ensure S3 prefix exists
+      run: |
+        echo "Ensuring that prefix '${{ steps.plugin_info.outputs.id }}/releases/latest' exists on '${{ env.AWS_PLUGINBUCKET_NAME }}'"
+        aws s3api put-object --bucket ${{ env.AWS_PLUGINBUCKET_NAME }} --key "${{ steps.plugin_info.outputs.id }}/releases/latest"
+
+    - name: Upload to S3
+      run: |
+        echo "Uploading './dist/dss-plugin-${{ steps.plugin_info.outputs.id }}-${{ steps.plugin_info.outputs.version }}.zip' to 's3://${{ env.AWS_PLUGINBUCKET_NAME }}/${{ steps.plugin_info.outputs.id }}/releases/latest/dss-plugin-${{ steps.plugin_info.outputs.id }}-latest.zip'"
+        aws s3 cp ./dist/dss-plugin-${{ steps.plugin_info.outputs.id }}-${{ steps.plugin_info.outputs.version }}.zip s3://${{ env.AWS_PLUGINBUCKET_NAME }}/${{ steps.plugin_info.outputs.id }}/releases/latest/dss-plugin-${{ steps.plugin_info.outputs.id }}-latest.zip
+
+    - name: Clean up release assets
+      run: make dist-clean

--- a/.github/workflows/upload-plugin-s3.yml
+++ b/.github/workflows/upload-plugin-s3.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Ensure S3 prefix exists
       run: |
         echo "Ensuring that prefix '${{ steps.plugin_info.outputs.id }}/releases/latest' exists on '${{ env.AWS_PLUGINBUCKET_NAME }}'"
-        aws s3api put-object --bucket ${{ env.AWS_PLUGINBUCKET_NAME }} --key "${{ steps.plugin_info.outputs.id }}/releases/latest"
+        aws s3api put-object --bucket ${{ env.AWS_PLUGINBUCKET_NAME }} --key "${{ steps.plugin_info.outputs.id }}/releases/latest/"
 
     - name: Upload to S3
       run: |

--- a/.github/workflows/upload-plugin-s3.yml
+++ b/.github/workflows/upload-plugin-s3.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
[sc-185521]
This new GitHub allows us to upload the latest version of the EKS plugin to S3.
The bucket can then be used by QA to run the weekly build using the latest unreleased version of the plugin rather than the released version when it's too late to catch issues.

In case you have issues with the AWS credentials configuration, message me because the IT terraform template may overwrite the ad-hoc permissions added for the forked repo.