### PR TITLE
Fix metrics API for eksctl >= 0.201.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 1.4.6 - Bugfix release
+- Fix metrics API on eksctl v0.201.0 and later
+
 ## Version 1.4.5 - Bugfix and improvements release
 - Fix Nvidia driver and ALB controller download issue.
 - Package Nvidia driver as fallback for creating GPU nodepools.

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "eks-clusters",
-    "version": "1.4.5",
+    "version": "1.4.6",
     "meta": {
         "label": "EKS clusters",
         "description": "Interact with Amazon Elastic Kubernetes Service clusters",

--- a/python-clusters/create-eks-cluster/cluster.json
+++ b/python-clusters/create-eks-cluster/cluster.json
@@ -73,11 +73,12 @@
             "description" : "Leave empty for current default of eksctl"
         },
         {
-             "name": "installMetricsServer",
-             "label": "Install metrics server",
-             "type": "BOOLEAN",
-             "mandatory" : true,
-             "defaultValue" : true
+            "name": "installMetricsServer",
+            "label": "Ensure metrics server installation",
+            "type": "BOOLEAN",
+            "mandatory" : true,
+            "defaultValue" : true,
+            "description": "Some versions of eksctl may install the metrics server with the default add-ons."
         },
         {
             "name": "privateCluster",

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -13,7 +13,7 @@ from dku_aws.aws_command import AwsCommand
 from dku_kube.kubeconfig import setup_creds_env
 from dku_kube.autoscaler import add_autoscaler_if_needed
 from dku_kube.gpu_driver import add_gpu_driver_if_needed
-from dku_kube.metrics_server import install_metrics_server
+from dku_kube.metrics_server import install_metrics_server_if_needed
 from dku_utils.cluster import make_overrides, get_connection_info
 from dku_utils.access import _is_none_or_blank
 from dku_utils.config_parser import get_region_arg, get_private_ip_from_metadata
@@ -297,7 +297,7 @@ class MyCluster(Cluster):
             add_gpu_driver_if_needed(self.cluster_id, kube_config_path, connection_info, gpu_taints)
 
         if self.config.get("installMetricsServer"):
-            install_metrics_server(kube_config_path)
+            install_metrics_server_if_needed(kube_config_path)
 
         c = EksctlCommand(args, connection_info)
         cluster_info = json.loads(c.run_and_get_output())[0]


### PR DESCRIPTION
Latest version of eksctl (0.201.0) includes the metrics server in the default add-ons.
This breaks the metrics API when we also try to install the metrics server upon cluster creation.

What we do is if the config requires it, before installing it, check if it's present. Only if not, install it using the config on the metrics-server GitHub page: https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml

## Test cases
* machine with older eksctl (< 0.201.0): In order test this on a new machine, ssh onto the machine, go to `/usr/local/bin` and delete eksctl if it exists. Then run the following command and start your cluster as usual.

```sh
cd /usr/local/bin
curl -sLO https://github.com/eksctl-io/eksctl/releases/download/v0.200.0/eksctl_Linux_amd64.tar.gz
tar -xzf eksctl_Linux_amd64.tar.gz
rm eksctl_Linux_amd64.tar.gz
```

* machine with newer eksctl (>= 0.201.0): May be easier to do first as the plugin will download the latest eksctl from github. Just create and start your cluster as normal. Ensure in the start.log that you find `Metrics server is already deployed on the cluster. Skipping install.` and also double check that the metrics are visible on the Clusters page.