### PR TITLE
[sc-267777] Increase kubectl and aws-iam-authenticator command timeout to 30s

### DIFF
--- a/python-lib/dku_kube/kubectl_command.py
+++ b/python-lib/dku_kube/kubectl_command.py
@@ -21,7 +21,7 @@ def run_with_timeout(cmd, env=None, timeout=3, nokill=False):
             return None, None
         else:
             p.kill()
-            raise Exception("Process did not finish after %s" % timeout)
+            raise Exception("Process did not finish after %s seconds" % timeout)
     out, err = p.communicate()
     rv = p.wait()
     if rv != 0:

--- a/python-lib/dku_utils/tools_version.py
+++ b/python-lib/dku_utils/tools_version.py
@@ -5,7 +5,7 @@ from dku_kube.kubectl_command import run_with_timeout
 
 def get_kubectl_version():
     cmd = ["kubectl", "version", "--client", "-o", "json"]
-    out, err = run_with_timeout(cmd)
+    out, err = run_with_timeout(cmd, timeout=30)
     return json.loads(out)["clientVersion"]
 
 
@@ -48,7 +48,7 @@ def strip_kubernetes_version(k8s_version_input):
 
 def get_authenticator_version():
     cmd = ["aws-iam-authenticator", "version", "-o", "json"]
-    out, err = run_with_timeout(cmd)
+    out, err = run_with_timeout(cmd, timeout=30)
     return json.loads(out)["Version"].lstrip("v")
 
 


### PR DESCRIPTION
[sc-267777]
A 3s timeout can result in these commands timing out because of EBS lazy-loading.