### PR TITLE
Encrypt EKS nodegroup storage by default

### DIFF
--- a/python-lib/dku_utils/node_pool.py
+++ b/python-lib/dku_utils/node_pool.py
@@ -70,6 +70,8 @@ def get_node_pool_yaml(node_pool, networking_settings):
     else:
         yaml["volumeSize"] = 200  # also defined as default value in parameter-sets/node-pool-request/parameter-set.json
 
+    yaml["volumeEncrypted"] = True
+
     yaml["desiredCapacity"] = node_pool.get("numNodes", 3)
     if node_pool.get("numNodesAutoscaling", False):
         yaml["iam"]["withAddonPolicies"]["autoScaler"] = True

--- a/python-runnables/add-node-pool/runnable.py
+++ b/python-runnables/add-node-pool/runnable.py
@@ -84,6 +84,7 @@ class MyRunnable(Runnable):
         # Adding node pool taints on the only node pool we create which is managed:
         node_group_taints = build_node_pool_taints_yaml(node_pool)
         yaml_dict["managedNodeGroups"][0]["taints"] = node_group_taints
+        yaml_dict["managedNodeGroups"][0]["volumeEncrypted"] = True
 
         # Adding propagateASGTags to the node group if it is autoscaled.
         # This propagates the labels/taints of the node group to the autoscaling group


### PR DESCRIPTION
[sc-225819]

Storage will be encrypted using the AWS-managed key. We currently won't offer to provide a KMS key identifier (tbd).

Clusters started before the upgrade will not enjoy the encryption. They must be restarted to use it. However node groups added with the macro will have their EBS disk encrypted.

In order to verify that the encryption is enabled, you must go to the AWS console, find your EKS cluster, check the node group and look into the launch template which will contain the definition for the disk with encryption enabled.