### PR TITLE
Improve EKS autoscaler image tag selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Next version
+- Improve autoscaler image version selection
+
 ## Version 1.5.0 - Feature and improvements release
 - Enable EBS volume encryption by default
 - Remove "Revoke public access" option as it clashes with "Fully private" option in configuration

--- a/Makefile
+++ b/Makefile
@@ -27,3 +27,6 @@ plugin:
 
 dist-clean:
 	rm -rf dist
+
+test:
+	python3 -m unittest discover -s tests -v

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,5 +1,5 @@
 {
-  "acceptedPythonInterpreters": ["PYTHON27", "PYTHON36", "PYTHON37", "PYTHON38", "PYTHON39", "PYTHON310", "PYTHON311"],
+  "acceptedPythonInterpreters": ["PYTHON37", "PYTHON38", "PYTHON39", "PYTHON310", "PYTHON311", "PYTHON312"],
   "forceConda": false,
   "installCorePackages": true,
   "installJupyterSupport": false,

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -2,3 +2,4 @@ PyYAML
 awscli
 ipaddress==1.0.23
 boto3
+oras

--- a/python-clusters/create-eks-cluster/cluster.json
+++ b/python-clusters/create-eks-cluster/cluster.json
@@ -101,9 +101,9 @@
         },
         {
             "name": "autoscalerRegistryURL",
-            "label": "Custom autoscaler registry URL",
+            "label": "Custom autoscaler registry",
             "type": "STRING",
-            "description": "If registry.k8s.io isn't reachable",
+            "description": "Registry host or namespace to use if registry.k8s.io isn't reachable.",
             "defaultValue" : "registry.k8s.io"
         },
         {

--- a/python-clusters/create-eks-cluster/cluster.json
+++ b/python-clusters/create-eks-cluster/cluster.json
@@ -107,6 +107,13 @@
             "defaultValue" : "registry.k8s.io"
         },
         {
+            "name": "autoscalerImageTagOverride",
+            "label": "Autoscaler image tag override",
+            "type": "STRING",
+            "description": "For airgapped registries or registries that block tag listing. Leave empty to discover a public-style version tag.",
+            "mandatory": false
+        },
+        {
             "name": "advanced",
             "label": "Use Advanced Configuration",
             "type": "BOOLEAN"

--- a/python-clusters/create-eks-cluster/cluster.py
+++ b/python-clusters/create-eks-cluster/cluster.py
@@ -295,9 +295,7 @@ class MyCluster(Cluster):
             logging.info("At least one node group is autoscaling, ensuring autoscaler")
             autoscaled_taints = list(autoscaled_node_pools_taints) if autoscaled_node_pools_taints else []
             autoscaler_registry_url = self.config.get("autoscalerRegistryURL", "registry.k8s.io")
-            add_autoscaler_if_needed(
-                self.cluster_id, self.config, cluster_info, kube_config_path, autoscaled_taints, autoscaler_registry_url
-            )
+            add_autoscaler_if_needed(self.cluster_id, self.config, cluster_info, kube_config_path, autoscaled_taints, autoscaler_registry_url)
 
         with open(kube_config_path, "r") as f:
             kube_config = yaml.safe_load(f)

--- a/python-lib/dku_kube/autoscaler.py
+++ b/python-lib/dku_kube/autoscaler.py
@@ -17,11 +17,25 @@ AUTOSCALER_TAG_RE = re.compile(r"^v([0-9]+)\.([0-9]+)\.([0-9]+)$")
 AUTOSCALER_MATCHING_VERSION_CUTOFF = (1, 12)
 AUTOSCALER_MATCHING_VERSION_CUTOFF_MINOR = "1.12"
 
-
-class AutoscalerImageSelection(object):
-    def __init__(self, image_tag, warning=None):
-        self.image_tag = image_tag
-        self.warning = warning
+# Used only when registry tag discovery is unavailable, which preserves the
+# existing custom-registry workflow for registries that do not expose tags/list.
+# Keep values pinned to tags known to exist in registry.k8s.io.
+# fmt: off
+AUTOSCALER_IMAGE_FALLBACKS = {
+    "1.24": "v1.24.3",
+    "1.25": "v1.25.3",
+    "1.26": "v1.26.4",
+    "1.27": "v1.27.3",
+    "1.28": "v1.28.0",
+    "1.29": "v1.29.5",
+    "1.30": "v1.30.7",
+    "1.31": "v1.31.5",
+    "1.32": "v1.32.7",
+    "1.33": "v1.33.4",
+    "1.34": "v1.34.3",
+    "1.35": "v1.35.0",
+}
+# fmt: on
 
 
 def has_autoscaler(kube_config_path):
@@ -67,71 +81,95 @@ def _discover_published_autoscaler_tags(autoscaler_registry_url):
     return [tag for tag in tags if _parse_autoscaler_tag(tag) is not None]
 
 
-def _latest_autoscaler_tag_for_minor(tags, kubernetes_minor=None):
+def _select_matching_autoscaler_tag_from_tags(tags, parsed_kubernetes_minor):
+    if parsed_kubernetes_minor >= AUTOSCALER_MATCHING_VERSION_CUTOFF:
+        # From Kubernetes 1.12 onward, upstream expects the autoscaler major/minor
+        # to match the Kubernetes major/minor; choose the latest patch for that minor.
+        matching_minor = parsed_kubernetes_minor
+    else:
+        # Before Kubernetes 1.12 there is no same-minor compatibility rule to apply.
+        # Use the first version where that rule exists, rather than jumping to latest.
+        matching_minor = AUTOSCALER_MATCHING_VERSION_CUTOFF
+
     matching_tags = []
     for tag in tags:
         parsed_tag = _parse_autoscaler_tag(tag)
-        if parsed_tag is None:
-            continue
-        if kubernetes_minor is not None and "%s.%s" % (parsed_tag[0], parsed_tag[1]) != kubernetes_minor:
-            continue
-        matching_tags.append((parsed_tag, tag))
+        if parsed_tag is not None and parsed_tag[:2] == matching_minor:
+            matching_tags.append((parsed_tag, tag))
 
-    if not matching_tags:
-        return None
-
-    matching_tags.sort()
-    return matching_tags[-1][1]
+    if matching_tags:
+        matching_tags.sort()
+        return matching_tags[-1][1]
 
 
 def select_autoscaler_image(kubernetes_version, autoscaler_registry_url, autoscaler_image_tag_override=None):
-    kubernetes_major, kubernetes_minor, kubernetes_minor_string = parse_kubernetes_version(kubernetes_version)
+    kubernetes_major, kubernetes_minor, kubernetes_version_string = parse_kubernetes_version(kubernetes_version)
     parsed_kubernetes_minor = (kubernetes_major, kubernetes_minor)
 
     if not _is_none_or_blank(autoscaler_image_tag_override):
         autoscaler_image_tag_override = autoscaler_image_tag_override.strip()
         logging.info(
-            "Using configured cluster autoscaler image tag override %s for Kubernetes %s" % (autoscaler_image_tag_override, kubernetes_minor_string)
+            "Using configured cluster autoscaler image tag override %s for Kubernetes %s" % (autoscaler_image_tag_override, kubernetes_version_string)
         )
-        return AutoscalerImageSelection(autoscaler_image_tag_override)
+        return autoscaler_image_tag_override
 
     try:
         published_tags = _discover_published_autoscaler_tags(autoscaler_registry_url)
-        if parsed_kubernetes_minor >= AUTOSCALER_MATCHING_VERSION_CUTOFF:
-            # From Kubernetes 1.12 onward, upstream expects the autoscaler major/minor
-            # to match the Kubernetes major/minor; choose the latest patch for that minor.
-            matching_tag = _latest_autoscaler_tag_for_minor(published_tags, kubernetes_minor_string)
-            if matching_tag is not None:
-                return AutoscalerImageSelection(matching_tag)
+        selected_tag = _select_matching_autoscaler_tag_from_tags(published_tags, parsed_kubernetes_minor)
+
+        if selected_tag is None:
+            logging.warning(
+                "No published cluster autoscaler image tag matches Kubernetes %s in registry %s. Fallback will be used."
+                % (
+                    kubernetes_version_string,
+                    autoscaler_registry_url,
+                )
+            )
+        elif parsed_kubernetes_minor < AUTOSCALER_MATCHING_VERSION_CUTOFF:
+            logging.warning(
+                "Kubernetes %s is below the cluster autoscaler version-matching cutoff %s. Using tag %s from registry %s."
+                % (
+                    kubernetes_version_string,
+                    AUTOSCALER_MATCHING_VERSION_CUTOFF_MINOR,
+                    selected_tag,
+                    autoscaler_registry_url,
+                )
+            )
+            return selected_tag
         else:
-            # Before Kubernetes 1.12 there is no same-minor compatibility rule to apply.
-            # Use the first version where that rule exists, rather than jumping to latest.
-            matching_tag = _latest_autoscaler_tag_for_minor(published_tags, AUTOSCALER_MATCHING_VERSION_CUTOFF_MINOR)
-            if matching_tag is not None:
-                warning = (
-                    "Kubernetes %s is below the cluster autoscaler version-matching cutoff 1.12. Using latest published %s tag %s from registry %s."
-                ) % (kubernetes_minor_string, AUTOSCALER_MATCHING_VERSION_CUTOFF_MINOR, matching_tag, autoscaler_registry_url)
-                logging.warning(warning)
-                return AutoscalerImageSelection(matching_tag, warning)
-
-        latest_tag = _latest_autoscaler_tag_for_minor(published_tags)
-        if latest_tag is not None:
-            if parsed_kubernetes_minor < AUTOSCALER_MATCHING_VERSION_CUTOFF:
-                warning = (
-                    "Kubernetes %s is below the cluster autoscaler version-matching cutoff 1.12, "
-                    "but no published %s tag exists in registry %s. Using latest published tag %s instead."
-                ) % (kubernetes_minor_string, AUTOSCALER_MATCHING_VERSION_CUTOFF_MINOR, autoscaler_registry_url, latest_tag)
-            else:
-                warning = (
-                    "No published cluster autoscaler image tag matches Kubernetes %s in registry %s. "
-                    "Using latest published tag %s instead; this may be unsupported by Kubernetes/AWS compatibility guidance."
-                ) % (kubernetes_minor_string, autoscaler_registry_url, latest_tag)
-            logging.warning(warning)
-            return AutoscalerImageSelection(latest_tag, warning)
+            logging.info("Using cluster autoscaler image tag %s for Kubernetes %s" % (selected_tag, kubernetes_version_string))
+            return selected_tag
     except (requests.RequestException, ValueError, KeyError) as e:
-        raise Exception("Unable to retrieve published cluster autoscaler image tags from registry %s: %s" % (autoscaler_registry_url, e))
+        logging.warning(
+            "Unable to retrieve published cluster autoscaler image tags from registry %s. Fallback will be used.\n %s." % (autoscaler_registry_url, e)
+        )
 
-    raise Exception("No published cluster autoscaler image tags found in registry %s" % autoscaler_registry_url)
+    fallback_tags = list(AUTOSCALER_IMAGE_FALLBACKS.values())
+    fallback_tag = _select_matching_autoscaler_tag_from_tags(fallback_tags, parsed_kubernetes_minor)
+    if fallback_tag is not None:
+        if parsed_kubernetes_minor < AUTOSCALER_MATCHING_VERSION_CUTOFF:
+            logging.warning(
+                "Kubernetes %s is below the cluster autoscaler version-matching cutoff %s. Using bundled fallback tag %s."
+                % (
+                    kubernetes_version_string,
+                    AUTOSCALER_MATCHING_VERSION_CUTOFF_MINOR,
+                    fallback_tag,
+                )
+            )
+        else:
+            logging.info("Using bundled fallback tag %s for Kubernetes %s." % (fallback_tag, kubernetes_version_string))
+        return fallback_tag
+
+    latest_supported_version = sorted(AUTOSCALER_IMAGE_FALLBACKS.keys(), key=lambda version: tuple(int(part) for part in version.split(".")))[-1]
+    latest_fallback_tag = AUTOSCALER_IMAGE_FALLBACKS[latest_supported_version]
+    logging.info(
+        "No bundled fallback matches Kubernetes %s. Using latest bundled fallback tag %s instead."
+        % (
+            kubernetes_version_string,
+            latest_fallback_tag,
+        )
+    )
+    return latest_fallback_tag
 
 
 def add_autoscaler_if_needed(cluster_id, cluster_config, cluster_def, kube_config_path, taints, autoscaler_registry_url):
@@ -146,11 +184,10 @@ def add_autoscaler_if_needed(cluster_id, cluster_config, cluster_def, kube_confi
         autoscaler_file_path = "autoscaler.yaml"
 
         autoscaler_image_tag_override = cluster_config.get("autoscalerImageTagOverride", None)
-        autoscaler_image_selection = select_autoscaler_image(kubernetes_version, autoscaler_registry_url, autoscaler_image_tag_override)
-        autoscaler_image = autoscaler_image_selection.image_tag
+        autoscaler_image_tag = select_autoscaler_image(kubernetes_version, autoscaler_registry_url, autoscaler_image_tag_override)
 
         autoscaler_full_config = list(yaml.safe_load_all(get_autoscaler_roles()))
-        autoscaler_config = yaml.safe_load(get_autoscaler_config(cluster_id, autoscaler_image, autoscaler_registry_url))
+        autoscaler_config = yaml.safe_load(get_autoscaler_config(cluster_id, autoscaler_image_tag, autoscaler_registry_url))
         tolerations = set()
 
         # If there are any taints to patch the autoscaler with in the node group(s) to create,
@@ -173,9 +210,6 @@ def add_autoscaler_if_needed(cluster_id, cluster_config, cluster_def, kube_confi
         cmd = ["kubectl", "create", "-f", os.path.abspath(autoscaler_file_path)]
         logging.info("Create autoscaler with : %s" % json.dumps(cmd))
         run_with_timeout(cmd, env=env, timeout=5)
-        return autoscaler_image_selection
-
-    return None
 
 
 def get_autoscaler_roles():

--- a/python-lib/dku_kube/autoscaler.py
+++ b/python-lib/dku_kube/autoscaler.py
@@ -1,28 +1,27 @@
 import os
 import json
 import logging
+import re
+import urllib.parse
+import requests
 import yaml
 from .kubectl_command import run_with_timeout
 from dku_utils.access import _is_none_or_blank
-from dku_utils.tools_version import strip_kubernetes_version
+from dku_utils.tools_version import parse_kubernetes_version, strip_kubernetes_version
 from dku_utils.taints import Toleration
 
-# fmt: off
-AUTOSCALER_IMAGES = {
-  "1.24": "v1.24.3",
-  "1.25": "v1.25.3",
-  "1.26": "v1.26.4",
-  "1.27": "v1.27.3",
-  "1.28": "v1.28.0",
-  "1.29": "v1.29.5",
-  "1.30": "v1.30.7",
-  "1.31": "v1.31.5",
-  "1.32": "v1.32.7",
-  "1.33": "v1.33.4",
-  "1.34": "v1.34.3",
-  "1.35": "v1.35.1"
-}
-# fmt: on
+AUTOSCALER_IMAGE_REPOSITORY = "autoscaling/cluster-autoscaler"
+AUTOSCALER_TAG_RE = re.compile(r"^v([0-9]+)\.([0-9]+)\.([0-9]+)$")
+# Upstream Cluster Autoscaler compatibility guidance says autoscaler and
+# Kubernetes major/minor versions match from Kubernetes 1.12 onward.
+AUTOSCALER_MATCHING_VERSION_CUTOFF = (1, 12)
+AUTOSCALER_MATCHING_VERSION_CUTOFF_MINOR = "1.12"
+
+
+class AutoscalerImageSelection(object):
+    def __init__(self, image_tag, warning=None):
+        self.image_tag = image_tag
+        self.warning = warning
 
 
 def has_autoscaler(kube_config_path):
@@ -34,19 +33,121 @@ def has_autoscaler(kube_config_path):
     return len(out.strip()) > 0
 
 
+def _parse_autoscaler_tag(tag):
+    match = AUTOSCALER_TAG_RE.match(tag)
+    if match is None:
+        return None
+    return tuple(int(part) for part in match.groups())
+
+
+def _get_registry_tags_url(autoscaler_registry_url):
+    registry_url = autoscaler_registry_url.rstrip("/")
+    parsed_registry_url = urllib.parse.urlparse(registry_url)
+    if parsed_registry_url.scheme == "":
+        parsed_registry_url = urllib.parse.urlparse("https://%s" % registry_url)
+
+    repository_path = "/".join(path_part.strip("/") for path_part in [parsed_registry_url.path, AUTOSCALER_IMAGE_REPOSITORY] if path_part.strip("/"))
+    return "%s://%s/v2/%s/tags/list" % (parsed_registry_url.scheme, parsed_registry_url.netloc, repository_path)
+
+
+def _discover_published_autoscaler_tags(autoscaler_registry_url):
+    tags_url = _get_registry_tags_url(autoscaler_registry_url)
+    logging.info("Retrieving published cluster autoscaler image tags from %s" % tags_url)
+
+    response = requests.get(tags_url, headers={"Accept": "application/json", "User-Agent": "DSS EKS Plugin"}, timeout=10)
+    if not response.ok:
+        logging.warning(
+            "Retrieving the cluster autoscaler image tags from URL '%s' failed with status: %s %s" % (tags_url, response.status_code, response.reason)
+        )
+        logging.warning("Content of failed request: %s" % response.content)
+        response.raise_for_status()
+
+    tags_response = response.json()
+    tags = tags_response.get("tags", [])
+    return [tag for tag in tags if _parse_autoscaler_tag(tag) is not None]
+
+
+def _latest_autoscaler_tag_for_minor(tags, kubernetes_minor=None):
+    matching_tags = []
+    for tag in tags:
+        parsed_tag = _parse_autoscaler_tag(tag)
+        if parsed_tag is None:
+            continue
+        if kubernetes_minor is not None and "%s.%s" % (parsed_tag[0], parsed_tag[1]) != kubernetes_minor:
+            continue
+        matching_tags.append((parsed_tag, tag))
+
+    if not matching_tags:
+        return None
+
+    matching_tags.sort()
+    return matching_tags[-1][1]
+
+
+def select_autoscaler_image(kubernetes_version, autoscaler_registry_url, autoscaler_image_tag_override=None):
+    kubernetes_major, kubernetes_minor, kubernetes_minor_string = parse_kubernetes_version(kubernetes_version)
+    parsed_kubernetes_minor = (kubernetes_major, kubernetes_minor)
+
+    if not _is_none_or_blank(autoscaler_image_tag_override):
+        autoscaler_image_tag_override = autoscaler_image_tag_override.strip()
+        logging.info(
+            "Using configured cluster autoscaler image tag override %s for Kubernetes %s" % (autoscaler_image_tag_override, kubernetes_minor_string)
+        )
+        return AutoscalerImageSelection(autoscaler_image_tag_override)
+
+    try:
+        published_tags = _discover_published_autoscaler_tags(autoscaler_registry_url)
+        if parsed_kubernetes_minor >= AUTOSCALER_MATCHING_VERSION_CUTOFF:
+            # From Kubernetes 1.12 onward, upstream expects the autoscaler major/minor
+            # to match the Kubernetes major/minor; choose the latest patch for that minor.
+            matching_tag = _latest_autoscaler_tag_for_minor(published_tags, kubernetes_minor_string)
+            if matching_tag is not None:
+                return AutoscalerImageSelection(matching_tag)
+        else:
+            # Before Kubernetes 1.12 there is no same-minor compatibility rule to apply.
+            # Use the first version where that rule exists, rather than jumping to latest.
+            matching_tag = _latest_autoscaler_tag_for_minor(published_tags, AUTOSCALER_MATCHING_VERSION_CUTOFF_MINOR)
+            if matching_tag is not None:
+                warning = (
+                    "Kubernetes %s is below the cluster autoscaler version-matching cutoff 1.12. Using latest published %s tag %s from registry %s."
+                ) % (kubernetes_minor_string, AUTOSCALER_MATCHING_VERSION_CUTOFF_MINOR, matching_tag, autoscaler_registry_url)
+                logging.warning(warning)
+                return AutoscalerImageSelection(matching_tag, warning)
+
+        latest_tag = _latest_autoscaler_tag_for_minor(published_tags)
+        if latest_tag is not None:
+            if parsed_kubernetes_minor < AUTOSCALER_MATCHING_VERSION_CUTOFF:
+                warning = (
+                    "Kubernetes %s is below the cluster autoscaler version-matching cutoff 1.12, "
+                    "but no published %s tag exists in registry %s. Using latest published tag %s instead."
+                ) % (kubernetes_minor_string, AUTOSCALER_MATCHING_VERSION_CUTOFF_MINOR, autoscaler_registry_url, latest_tag)
+            else:
+                warning = (
+                    "No published cluster autoscaler image tag matches Kubernetes %s in registry %s. "
+                    "Using latest published tag %s instead; this may be unsupported by Kubernetes/AWS compatibility guidance."
+                ) % (kubernetes_minor_string, autoscaler_registry_url, latest_tag)
+            logging.warning(warning)
+            return AutoscalerImageSelection(latest_tag, warning)
+    except (requests.RequestException, ValueError, KeyError) as e:
+        raise Exception("Unable to retrieve published cluster autoscaler image tags from registry %s: %s" % (autoscaler_registry_url, e))
+
+    raise Exception("No published cluster autoscaler image tags found in registry %s" % autoscaler_registry_url)
+
+
 def add_autoscaler_if_needed(cluster_id, cluster_config, cluster_def, kube_config_path, taints, autoscaler_registry_url):
     if not has_autoscaler(kube_config_path):
         kubernetes_version = cluster_config.get("k8sVersion", None)
-        if _is_none_or_blank(kubernetes_version) or kubernetes_version == "latest":
+        if _is_none_or_blank(kubernetes_version) or kubernetes_version.strip().lower() == "latest":
             kubernetes_version = cluster_def.get("Version")
+        if _is_none_or_blank(kubernetes_version):
+            raise Exception("No Kubernetes version found in cluster config or EKS cluster definition")
 
         kubernetes_version = strip_kubernetes_version(kubernetes_version)
         autoscaler_file_path = "autoscaler.yaml"
 
-        if float(kubernetes_version) < 1.24:
-            autoscaler_image = AUTOSCALER_IMAGES.get("1.24", "v1.24.3")
-        else:
-            autoscaler_image = AUTOSCALER_IMAGES.get(kubernetes_version, "v1.35.1")
+        autoscaler_image_tag_override = cluster_config.get("autoscalerImageTagOverride", None)
+        autoscaler_image_selection = select_autoscaler_image(kubernetes_version, autoscaler_registry_url, autoscaler_image_tag_override)
+        autoscaler_image = autoscaler_image_selection.image_tag
 
         autoscaler_full_config = list(yaml.safe_load_all(get_autoscaler_roles()))
         autoscaler_config = yaml.safe_load(get_autoscaler_config(cluster_id, autoscaler_image, autoscaler_registry_url))
@@ -72,6 +173,9 @@ def add_autoscaler_if_needed(cluster_id, cluster_config, cluster_def, kube_confi
         cmd = ["kubectl", "create", "-f", os.path.abspath(autoscaler_file_path)]
         logging.info("Create autoscaler with : %s" % json.dumps(cmd))
         run_with_timeout(cmd, env=env, timeout=5)
+        return autoscaler_image_selection
+
+    return None
 
 
 def get_autoscaler_roles():
@@ -247,4 +351,3 @@ spec:
           hostPath:
             path: "/etc/ssl/certs/ca-bundle.crt"
 """ % {"autoscalerimageversion": autoscaler_image_version, "clusterid": cluster_id, "autoscalerregistryurl": autoscaler_registry_url}
-

--- a/python-lib/dku_kube/autoscaler.py
+++ b/python-lib/dku_kube/autoscaler.py
@@ -2,13 +2,14 @@ import os
 import json
 import logging
 import re
-import urllib.parse
 import requests
 import yaml
 from .kubectl_command import run_with_timeout
 from dku_utils.access import _is_none_or_blank
 from dku_utils.tools_version import parse_kubernetes_version, strip_kubernetes_version
 from dku_utils.taints import Toleration
+from oras.provider import Registry
+
 
 AUTOSCALER_IMAGE_REPOSITORY = "autoscaling/cluster-autoscaler"
 AUTOSCALER_TAG_RE = re.compile(r"^v([0-9]+)\.([0-9]+)\.([0-9]+)$")
@@ -36,6 +37,7 @@ AUTOSCALER_IMAGE_FALLBACKS = {
     "1.35": "v1.35.0",
 }
 # fmt: on
+k8s_image_client = Registry()
 
 
 def has_autoscaler(kube_config_path):
@@ -54,31 +56,11 @@ def _parse_autoscaler_tag(tag):
     return tuple(int(part) for part in match.groups())
 
 
-def _get_registry_tags_url(autoscaler_registry_url):
-    registry_url = autoscaler_registry_url.rstrip("/")
-    parsed_registry_url = urllib.parse.urlparse(registry_url)
-    if parsed_registry_url.scheme == "":
-        parsed_registry_url = urllib.parse.urlparse("https://%s" % registry_url)
-
-    repository_path = "/".join(path_part.strip("/") for path_part in [parsed_registry_url.path, AUTOSCALER_IMAGE_REPOSITORY] if path_part.strip("/"))
-    return "%s://%s/v2/%s/tags/list" % (parsed_registry_url.scheme, parsed_registry_url.netloc, repository_path)
-
-
 def _discover_published_autoscaler_tags(autoscaler_registry_url):
-    tags_url = _get_registry_tags_url(autoscaler_registry_url)
-    logging.info("Retrieving published cluster autoscaler image tags from %s" % tags_url)
+    repository_url = "/".join(path_part.strip("/") for path_part in [autoscaler_registry_url, AUTOSCALER_IMAGE_REPOSITORY])
+    logging.info("Retrieving published cluster autoscaler image tags from %s" % repository_url)
 
-    response = requests.get(tags_url, headers={"Accept": "application/json", "User-Agent": "DSS EKS Plugin"}, timeout=10)
-    if not response.ok:
-        logging.warning(
-            "Retrieving the cluster autoscaler image tags from URL '%s' failed with status: %s %s" % (tags_url, response.status_code, response.reason)
-        )
-        logging.warning("Content of failed request: %s" % response.content)
-        response.raise_for_status()
-
-    tags_response = response.json()
-    tags = tags_response.get("tags", [])
-    return [tag for tag in tags if _parse_autoscaler_tag(tag) is not None]
+    return [tag for tag in k8s_image_client.get_tags(repository_url) if _parse_autoscaler_tag(tag) is not None]
 
 
 def _select_matching_autoscaler_tag_from_tags(tags, parsed_kubernetes_minor):
@@ -139,7 +121,7 @@ def select_autoscaler_image(kubernetes_version, autoscaler_registry_url, autosca
         else:
             logging.info("Using cluster autoscaler image tag %s for Kubernetes %s" % (selected_tag, kubernetes_version_string))
             return selected_tag
-    except (requests.RequestException, ValueError, KeyError) as e:
+    except (requests.RequestException, ValueError) as e:
         logging.warning(
             "Unable to retrieve published cluster autoscaler image tags from registry %s. Fallback will be used.\n %s." % (autoscaler_registry_url, e)
         )

--- a/python-lib/dku_kube/autoscaler.py
+++ b/python-lib/dku_kube/autoscaler.py
@@ -13,7 +13,14 @@ AUTOSCALER_IMAGES = {
   "1.25": "v1.25.3",
   "1.26": "v1.26.4",
   "1.27": "v1.27.3",
-  "1.28": "v1.28.0"
+  "1.28": "v1.28.0",
+  "1.29": "v1.29.5",
+  "1.30": "v1.30.7",
+  "1.31": "v1.31.5",
+  "1.32": "v1.32.7",
+  "1.33": "v1.33.4",
+  "1.34": "v1.34.3",
+  "1.35": "v1.35.1"
 }
 # fmt: on
 
@@ -30,7 +37,7 @@ def has_autoscaler(kube_config_path):
 def add_autoscaler_if_needed(cluster_id, cluster_config, cluster_def, kube_config_path, taints, autoscaler_registry_url):
     if not has_autoscaler(kube_config_path):
         kubernetes_version = cluster_config.get("k8sVersion", None)
-        if _is_none_or_blank(kubernetes_version):
+        if _is_none_or_blank(kubernetes_version) or kubernetes_version == "latest":
             kubernetes_version = cluster_def.get("Version")
 
         kubernetes_version = strip_kubernetes_version(kubernetes_version)
@@ -39,7 +46,7 @@ def add_autoscaler_if_needed(cluster_id, cluster_config, cluster_def, kube_confi
         if float(kubernetes_version) < 1.24:
             autoscaler_image = AUTOSCALER_IMAGES.get("1.24", "v1.24.3")
         else:
-            autoscaler_image = AUTOSCALER_IMAGES.get(kubernetes_version, "v1.28.0")
+            autoscaler_image = AUTOSCALER_IMAGES.get(kubernetes_version, "v1.35.1")
 
         autoscaler_full_config = list(yaml.safe_load_all(get_autoscaler_roles()))
         autoscaler_config = yaml.safe_load(get_autoscaler_config(cluster_id, autoscaler_image, autoscaler_registry_url))

--- a/python-lib/dku_kube/autoscaler.py
+++ b/python-lib/dku_kube/autoscaler.py
@@ -13,10 +13,6 @@ from oras.provider import Registry
 
 AUTOSCALER_IMAGE_REPOSITORY = "autoscaling/cluster-autoscaler"
 AUTOSCALER_TAG_RE = re.compile(r"^v([0-9]+)\.([0-9]+)\.([0-9]+)$")
-# Upstream Cluster Autoscaler compatibility guidance says autoscaler and
-# Kubernetes major/minor versions match from Kubernetes 1.12 onward.
-AUTOSCALER_MATCHING_VERSION_CUTOFF = (1, 12)
-AUTOSCALER_MATCHING_VERSION_CUTOFF_MINOR = "1.12"
 
 # Used only when registry tag discovery is unavailable, which preserves the
 # existing custom-registry workflow for registries that do not expose tags/list.
@@ -64,19 +60,10 @@ def _discover_published_autoscaler_tags(autoscaler_registry_url):
 
 
 def _select_matching_autoscaler_tag_from_tags(tags, parsed_kubernetes_minor):
-    if parsed_kubernetes_minor >= AUTOSCALER_MATCHING_VERSION_CUTOFF:
-        # From Kubernetes 1.12 onward, upstream expects the autoscaler major/minor
-        # to match the Kubernetes major/minor; choose the latest patch for that minor.
-        matching_minor = parsed_kubernetes_minor
-    else:
-        # Before Kubernetes 1.12 there is no same-minor compatibility rule to apply.
-        # Use the first version where that rule exists, rather than jumping to latest.
-        matching_minor = AUTOSCALER_MATCHING_VERSION_CUTOFF
-
     matching_tags = []
     for tag in tags:
         parsed_tag = _parse_autoscaler_tag(tag)
-        if parsed_tag is not None and parsed_tag[:2] == matching_minor:
+        if parsed_tag is not None and parsed_tag[:2] == parsed_kubernetes_minor:
             matching_tags.append((parsed_tag, tag))
 
     if matching_tags:
@@ -97,8 +84,12 @@ def select_autoscaler_image(kubernetes_version, autoscaler_registry_url, autosca
 
     try:
         published_tags = _discover_published_autoscaler_tags(autoscaler_registry_url)
+    except (requests.RequestException, ValueError) as e:
+        logging.warning(
+            "Unable to retrieve published cluster autoscaler image tags from registry %s. Fallback will be used.\n %s." % (autoscaler_registry_url, e)
+        )
+    else:
         selected_tag = _select_matching_autoscaler_tag_from_tags(published_tags, parsed_kubernetes_minor)
-
         if selected_tag is None:
             logging.warning(
                 "No published cluster autoscaler image tag matches Kubernetes %s in registry %s. Fallback will be used."
@@ -107,39 +98,14 @@ def select_autoscaler_image(kubernetes_version, autoscaler_registry_url, autosca
                     autoscaler_registry_url,
                 )
             )
-        elif parsed_kubernetes_minor < AUTOSCALER_MATCHING_VERSION_CUTOFF:
-            logging.warning(
-                "Kubernetes %s is below the cluster autoscaler version-matching cutoff %s. Using tag %s from registry %s."
-                % (
-                    kubernetes_version_string,
-                    AUTOSCALER_MATCHING_VERSION_CUTOFF_MINOR,
-                    selected_tag,
-                    autoscaler_registry_url,
-                )
-            )
-            return selected_tag
         else:
             logging.info("Using cluster autoscaler image tag %s for Kubernetes %s" % (selected_tag, kubernetes_version_string))
             return selected_tag
-    except (requests.RequestException, ValueError) as e:
-        logging.warning(
-            "Unable to retrieve published cluster autoscaler image tags from registry %s. Fallback will be used.\n %s." % (autoscaler_registry_url, e)
-        )
 
     fallback_tags = list(AUTOSCALER_IMAGE_FALLBACKS.values())
     fallback_tag = _select_matching_autoscaler_tag_from_tags(fallback_tags, parsed_kubernetes_minor)
     if fallback_tag is not None:
-        if parsed_kubernetes_minor < AUTOSCALER_MATCHING_VERSION_CUTOFF:
-            logging.warning(
-                "Kubernetes %s is below the cluster autoscaler version-matching cutoff %s. Using bundled fallback tag %s."
-                % (
-                    kubernetes_version_string,
-                    AUTOSCALER_MATCHING_VERSION_CUTOFF_MINOR,
-                    fallback_tag,
-                )
-            )
-        else:
-            logging.info("Using bundled fallback tag %s for Kubernetes %s." % (fallback_tag, kubernetes_version_string))
+        logging.info("Using bundled fallback tag %s for Kubernetes %s." % (fallback_tag, kubernetes_version_string))
         return fallback_tag
 
     latest_supported_version = sorted(AUTOSCALER_IMAGE_FALLBACKS.keys(), key=lambda version: tuple(int(part) for part in version.split(".")))[-1]

--- a/python-lib/dku_utils/tools_version.py
+++ b/python-lib/dku_utils/tools_version.py
@@ -2,6 +2,8 @@ import json
 import re
 from dku_kube.kubectl_command import run_with_timeout
 
+KUBERNETES_VERSION_RE = re.compile(r"^([0-9]+)\.([0-9]+)(?:\.([0-9]+))?$")
+
 
 def get_kubectl_version():
     cmd = ["kubectl", "version", "--client", "-o", "json"]
@@ -23,27 +25,41 @@ def get_kubectl_version_int(kubectl_version):
     Extracts the integers representing the major version and the minor version coming from outcome
     of `kubectl version` command
     """
-    # the kubectl version downloaded from Amazon website has a minor version finishing by '+'
-    # keeping only the first numeric sequence for the minor version
     if "major" not in kubectl_version or "minor" not in kubectl_version:
         raise Exception("Kubectl version found on the machine: %s. It is not correctly formatted" % kubectl_version_to_string(kubectl_version))
-    regex_minor_int = re.compile("^[^0-9]*([0-9]+)([^0-9].*$|$)")
-    search_results_minor_int = re.search(regex_minor_int, kubectl_version["minor"])
-    if not search_results_minor_int or not search_results_minor_int.groups():
+
+    # The kubectl version downloaded from Amazon can have a minor version ending with '+';
+    # normalize it before using the generic Kubernetes major/minor parser.
+    normalized_version = strip_kubernetes_version(kubectl_version_to_string(kubectl_version))
+    try:
+        major_int, minor_int, _ = parse_kubernetes_version(normalized_version)
+    except Exception:
         raise Exception("Kubectl version found on the machine: %s. It was not possible to parse" % kubectl_version_to_string(kubectl_version))
-    minor_int = int(search_results_minor_int.groups()[0])
-    return int(kubectl_version["major"]), minor_int
+    return major_int, minor_int
 
 
 def strip_kubernetes_version(k8s_version_input):
     """
     Removes any additional characters from the Kubernetes version specified in the cluster creation form
     """
-    regex_k8s_version = re.compile("^[^0-9]*([0-9]+\.?[0-9]+)([^0-9].*$|$)")
+    regex_k8s_version = re.compile(r"^[^0-9]*([0-9]+\.?[0-9]+)([^0-9].*$|$)")
     search_results_k8s_version = re.search(regex_k8s_version, k8s_version_input)
     if not search_results_k8s_version or not search_results_k8s_version.groups():
         raise Exception("Kubectl version specified: %s. No valid Kubernetes version found", k8s_version_input)
     return search_results_k8s_version.groups()[0]
+
+
+def parse_kubernetes_version(version):
+    """
+    Parses a Kubernetes version string and returns its major, minor, and major.minor string.
+    EKS cluster versions are usually major.minor, but a patch version is accepted too.
+    """
+    match = KUBERNETES_VERSION_RE.match(version)
+    if match is None:
+        raise Exception("Kubernetes version specified: %s. No valid Kubernetes major/minor version found" % version)
+    major = int(match.group(1))
+    minor = int(match.group(2))
+    return major, minor, "%s.%s" % (major, minor)
 
 
 def get_authenticator_version():

--- a/python-runnables/add-autoscaler/runnable.json
+++ b/python-runnables/add-autoscaler/runnable.json
@@ -28,9 +28,9 @@
         },
         {
             "name": "autoscalerRegistryURL",
-            "label": "Custom autoscaler registry URL",
+            "label": "Custom autoscaler registry",
             "type": "STRING",
-            "description": "If registry.k8s.io isn't reachable",
+            "description": "Registry host or namespace to use if registry.k8s.io isn't reachable.",
             "defaultValue" : "registry.k8s.io"
         },
         {

--- a/python-runnables/add-autoscaler/runnable.json
+++ b/python-runnables/add-autoscaler/runnable.json
@@ -32,6 +32,13 @@
             "type": "STRING",
             "description": "If registry.k8s.io isn't reachable",
             "defaultValue" : "registry.k8s.io"
+        },
+        {
+            "name": "autoscalerImageTagOverride",
+            "label": "Autoscaler image tag override",
+            "type": "STRING",
+            "description": "For airgapped registries or registries that block tag listing. Leave empty to discover a public-style version tag.",
+            "mandatory": false
         }
     ]
 }

--- a/python-runnables/add-autoscaler/runnable.py
+++ b/python-runnables/add-autoscaler/runnable.py
@@ -1,3 +1,5 @@
+import html
+
 from dataiku.runnables import Runnable
 from dku_kube.autoscaler import add_autoscaler_if_needed, has_autoscaler
 from dku_utils.cluster import get_cluster_from_dss_cluster
@@ -30,5 +32,7 @@ class MyRunnable(Runnable):
             return "<h5>An autoscaler pod already runs<h5>"
         else:
             autoscaler_registry_url = self.config.get("autoscalerRegistryURL", "registry.k8s.io")
-            add_autoscaler_if_needed(cluster_id, self.config, cluster_def, kube_config_path, [], autoscaler_registry_url)
-            return "<h5>Created an autoscaler pod<h5>"
+            autoscaler_image_selection = add_autoscaler_if_needed(cluster_id, self.config, cluster_def, kube_config_path, [], autoscaler_registry_url)
+            if autoscaler_image_selection is not None and autoscaler_image_selection.warning is not None:
+                return '<h5>Created an autoscaler pod</h5><div class="alert alert-warning">%s</div>' % html.escape(autoscaler_image_selection.warning)
+            return "<h5>Created an autoscaler pod</h5>"

--- a/python-runnables/add-autoscaler/runnable.py
+++ b/python-runnables/add-autoscaler/runnable.py
@@ -1,5 +1,3 @@
-import html
-
 from dataiku.runnables import Runnable
 from dku_kube.autoscaler import add_autoscaler_if_needed, has_autoscaler
 from dku_utils.cluster import get_cluster_from_dss_cluster
@@ -32,7 +30,5 @@ class MyRunnable(Runnable):
             return "<h5>An autoscaler pod already runs<h5>"
         else:
             autoscaler_registry_url = self.config.get("autoscalerRegistryURL", "registry.k8s.io")
-            autoscaler_image_selection = add_autoscaler_if_needed(cluster_id, self.config, cluster_def, kube_config_path, [], autoscaler_registry_url)
-            if autoscaler_image_selection is not None and autoscaler_image_selection.warning is not None:
-                return '<h5>Created an autoscaler pod</h5><div class="alert alert-warning">%s</div>' % html.escape(autoscaler_image_selection.warning)
+            add_autoscaler_if_needed(cluster_id, self.config, cluster_def, kube_config_path, [], autoscaler_registry_url)
             return "<h5>Created an autoscaler pod</h5>"

--- a/python-runnables/add-node-pool/runnable.json
+++ b/python-runnables/add-node-pool/runnable.json
@@ -46,6 +46,13 @@
             "type": "STRING",
             "description": "If registry.k8s.io isn't reachable",
             "defaultValue" : "registry.k8s.io"
+        },
+        {
+            "name": "autoscalerImageTagOverride",
+            "label": "Autoscaler image tag override",
+            "type": "STRING",
+            "description": "For airgapped registries or registries that block tag listing. Leave empty to discover a public-style version tag.",
+            "mandatory": false
         }
     ]
 }

--- a/python-runnables/add-node-pool/runnable.json
+++ b/python-runnables/add-node-pool/runnable.json
@@ -42,9 +42,9 @@
         },
         {
             "name": "autoscalerRegistryURL",
-            "label": "Custom autoscaler registry URL",
+            "label": "Custom autoscaler registry",
             "type": "STRING",
-            "description": "If registry.k8s.io isn't reachable",
+            "description": "Registry host or namespace to use if registry.k8s.io isn't reachable.",
             "defaultValue" : "registry.k8s.io"
         },
         {

--- a/python-runnables/add-node-pool/runnable.py
+++ b/python-runnables/add-node-pool/runnable.py
@@ -108,7 +108,9 @@ class MyRunnable(Runnable):
         if node_pool.get("numNodesAutoscaling", False):
             logging.info("Nodegroup is autoscaling, ensuring autoscaler")
             autoscaler_registry_url = self.config.get("autoscalerRegistryURL", "registry.k8s.io")
-            add_autoscaler_if_needed(cluster_id, self.config, cluster_data.get("cluster"), kube_config_path, node_group_taints, autoscaler_registry_url)
+            add_autoscaler_if_needed(
+                cluster_id, self.config, cluster_data.get("cluster"), kube_config_path, node_group_taints, autoscaler_registry_url
+            )
 
         if node_pool.get("enableGPU", False):
             logging.info("Nodegroup is GPU-enabled, ensuring NVIDIA GPU Drivers")

--- a/tests/test_autoscaler.py
+++ b/tests/test_autoscaler.py
@@ -1,0 +1,119 @@
+import os
+import sys
+import types
+import unittest
+
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PYTHON_LIB = os.path.join(REPO_ROOT, "python-lib")
+if PYTHON_LIB not in sys.path:
+    sys.path.insert(0, PYTHON_LIB)
+
+
+class FakeRegistry(object):
+    def __init__(self):
+        self.tags = []
+        self.containers = []
+        self.error = None
+
+    def get_tags(self, container, N=None):
+        self.containers.append(container)
+        if self.error is not None:
+            raise self.error
+        return list(self.tags)
+
+
+sys.modules.setdefault("yaml", types.SimpleNamespace())
+sys.modules.setdefault("six", types.SimpleNamespace(text_type=str))
+sys.modules.setdefault("requests", types.SimpleNamespace(RequestException=Exception))
+sys.modules.setdefault("oras", types.SimpleNamespace())
+sys.modules["oras.provider"] = types.SimpleNamespace(Registry=FakeRegistry)
+
+from dku_kube import autoscaler  # noqa: E402
+
+
+class AutoscalerImageSelectionTest(unittest.TestCase):
+    def setUp(self):
+        autoscaler.k8s_image_client = FakeRegistry()
+
+    def test_parse_autoscaler_tag_accepts_only_full_patch_versions(self):
+        self.assertEqual((1, 35, 0), autoscaler._parse_autoscaler_tag("v1.35.0"))
+        self.assertEqual((12, 3, 456), autoscaler._parse_autoscaler_tag("v12.3.456"))
+
+        self.assertIsNone(autoscaler._parse_autoscaler_tag("latest"))
+        self.assertIsNone(autoscaler._parse_autoscaler_tag("v1.35"))
+        self.assertIsNone(autoscaler._parse_autoscaler_tag("1.35.0"))
+        self.assertIsNone(autoscaler._parse_autoscaler_tag("dss-qa-1_35"))
+
+    def test_discover_published_autoscaler_tags_filters_non_version_tags(self):
+        autoscaler.k8s_image_client.tags = ["latest", "v1.35", "v1.34.3", "v1.35.0", "dss-qa-1_35"]
+
+        self.assertEqual(["v1.34.3", "v1.35.0"], autoscaler._discover_published_autoscaler_tags("registry.k8s.io"))
+        self.assertEqual(["registry.k8s.io/autoscaling/cluster-autoscaler"], autoscaler.k8s_image_client.containers)
+
+    def test_discover_published_autoscaler_tags_keeps_registry_namespace_prefix(self):
+        autoscaler.k8s_image_client.tags = ["v1.35.0"]
+
+        self.assertEqual(
+            ["v1.35.0"],
+            autoscaler._discover_published_autoscaler_tags("123456789012.dkr.ecr.eu-west-1.amazonaws.com/valrutz"),
+        )
+        self.assertEqual(
+            ["123456789012.dkr.ecr.eu-west-1.amazonaws.com/valrutz/autoscaling/cluster-autoscaler"],
+            autoscaler.k8s_image_client.containers,
+        )
+
+    def test_select_matching_autoscaler_tag_from_tags_uses_latest_patch_for_minor(self):
+        tags = ["v1.35.0", "v1.33.4", "v1.35.2", "v1.35.1", "not-a-version"]
+
+        self.assertEqual("v1.35.2", autoscaler._select_matching_autoscaler_tag_from_tags(tags, (1, 35)))
+        self.assertEqual("v1.33.4", autoscaler._select_matching_autoscaler_tag_from_tags(tags, (1, 33)))
+        self.assertIsNone(autoscaler._select_matching_autoscaler_tag_from_tags(tags, (1, 36)))
+
+    def test_select_autoscaler_image_uses_override_without_discovery(self):
+        autoscaler.k8s_image_client.error = ValueError("discovery should not be called")
+
+        selected_tag = autoscaler.select_autoscaler_image("1.35", "registry.k8s.io", "dss-qa-1_35")
+
+        self.assertEqual("dss-qa-1_35", selected_tag)
+        self.assertEqual([], autoscaler.k8s_image_client.containers)
+
+    def test_select_autoscaler_image_uses_matching_published_tag(self):
+        autoscaler.k8s_image_client.tags = ["v1.33.3", "v1.35.0", "v1.33.4"]
+
+        self.assertEqual("v1.33.4", autoscaler.select_autoscaler_image("1.33", "registry.k8s.io"))
+
+    def test_select_autoscaler_image_accepts_kubernetes_patch_version(self):
+        autoscaler.k8s_image_client.tags = ["v1.35.0", "v1.35.1"]
+
+        self.assertEqual("v1.35.1", autoscaler.select_autoscaler_image("1.35.7", "registry.k8s.io"))
+
+    def test_select_autoscaler_image_falls_back_to_bundled_matching_tag_when_discovery_fails(self):
+        autoscaler.k8s_image_client.error = ValueError("tags/list unavailable")
+
+        self.assertEqual("v1.33.4", autoscaler.select_autoscaler_image("1.33", "private.example"))
+
+    def test_select_autoscaler_image_uses_latest_bundled_tag_when_discovery_fails_and_no_fallback_matches(self):
+        autoscaler.k8s_image_client.error = ValueError("tags/list unavailable")
+
+        self.assertEqual("v1.35.0", autoscaler.select_autoscaler_image("1.36", "private.example"))
+
+    def test_select_autoscaler_image_falls_back_to_bundled_matching_tag_when_published_match_missing(self):
+        autoscaler.k8s_image_client.tags = ["v1.35.0"]
+
+        self.assertEqual("v1.33.4", autoscaler.select_autoscaler_image("1.33", "registry.k8s.io"))
+
+    def test_select_autoscaler_image_uses_latest_bundled_tag_when_no_matching_fallback_exists(self):
+        autoscaler.k8s_image_client.tags = ["v1.35.0"]
+
+        self.assertEqual("v1.35.0", autoscaler.select_autoscaler_image("1.36", "registry.k8s.io"))
+
+    def test_get_autoscaler_config_uses_selected_registry_and_tag(self):
+        config = autoscaler.get_autoscaler_config("cluster-1", "v1.35.0", "registry.example.com/prefix/")
+
+        self.assertIn("image: registry.example.com/prefix/autoscaling/cluster-autoscaler:v1.35.0", config)
+        self.assertIn("k8s.io/cluster-autoscaler/cluster-1", config)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Autoscaler Image Selection Test Plan

## PR Scope

Validate that the EKS plugin can select a cluster autoscaler image without relying only on a hardcoded Kubernetes-to-autoscaler map.

The change covers:

- selecting an autoscaler tag from the configured registry tags list when a matching Kubernetes major/minor exists;
- falling back to bundled known-good tags when registry tag discovery fails or has no matching tag;
- allowing an explicit autoscaler image tag override for private or airgapped registries;
- keeping fallback details in logs only, not in runnable UI output.

## Sources

- AWS EKS available Kubernetes versions:
  https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#available-versions
- Cluster autoscaler tags:
  https://github.com/kubernetes/autoscaler/tags
- Cluster autoscaler image registry:
  `registry.k8s.io/autoscaling/cluster-autoscaler`

## Preflight

Confirm the Kubernetes versions are available in the target AWS region before creating EKS clusters:

```bash
export AWS_REGION=eu-west-1

aws eks describe-cluster-versions --region "$AWS_REGION"
```

For this PR, prioritize currently supported EKS versions that exercise the selector behavior:

- `1.35`: expected to have a matching autoscaler tag.
- `1.33`: expected to have a matching autoscaler tag and verifies non-latest supported minors.
- `1.36`: expected to exercise the fallback path if no `v1.36.x` autoscaler tag is published.

Do not add `1.11` or `1.12` E2E clusters unless an existing legacy environment is already available. They are outside the practical EKS coverage for this PR.

## Private ECR Setup

Create or reuse one ECR repository whose path matches the image path built by the plugin:

```text
<autoscalerRegistryURL>/autoscaling/cluster-autoscaler:<tag>
```

Example setup:

```bash
export AWS_REGION=eu-west-1
export AWS_ACCOUNT_ID=236706865914
export ECR_REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
export ECR_REPO_PREFIX="${YOUR_OWN_REPO_PREFIX}"
export ECR_REPO="${ECR_REPO_PREFIX}/autoscaling/cluster-autoscaler"

aws ecr create-repository \
  --region "$AWS_REGION" \
  --repository-name "$ECR_REPO"

aws ecr get-login-password --region "$AWS_REGION" \
  | docker login --username AWS --password-stdin "$ECR_REGISTRY"
```

Push only the images needed by the private-registry override scenarios:

```bash
docker pull registry.k8s.io/autoscaling/cluster-autoscaler:v1.35.0

docker tag registry.k8s.io/autoscaling/cluster-autoscaler:v1.35.0 \
  "$ECR_REGISTRY/$ECR_REPO:dss-qa-1_35"

docker tag registry.k8s.io/autoscaling/cluster-autoscaler:v1.35.0 \
  "$ECR_REGISTRY/$ECR_REPO:v1.35"

docker push "$ECR_REGISTRY/$ECR_REPO:dss-qa-1_35"
docker push "$ECR_REGISTRY/$ECR_REPO:v1.35"
```

Ensure the worker node role can pull from the private ECR repository:

- `ecr:GetAuthorizationToken`
- `ecr:BatchCheckLayerAvailability`
- `ecr:BatchGetImage`
- `ecr:GetDownloadUrlForLayer`

Also ensure the worker node role has the AWS permissions required by cluster autoscaler itself. The plugin deploys the upstream AWS cloud-provider autoscaler manifest; at runtime the pod must be able to inspect and update Auto Scaling Groups. If the cluster or node group was not created with the usual autoscaling permissions, attach a policy that allows the autoscaler actions needed for EKS node groups, including:

- `autoscaling:DescribeAutoScalingGroups`
- `autoscaling:DescribeAutoScalingInstances`
- `autoscaling:DescribeLaunchConfigurations`
- `autoscaling:DescribeScalingActivities`
- `autoscaling:DescribeTags`
- `autoscaling:SetDesiredCapacity`
- `autoscaling:TerminateInstanceInAutoScalingGroup`
- `ec2:DescribeInstanceTypes`
- `ec2:DescribeLaunchTemplateVersions`

If pushing from a DSS instance or test instance, that role also needs push permissions such as:

- `ecr:InitiateLayerUpload`
- `ecr:UploadLayerPart`
- `ecr:CompleteLayerUpload`
- `ecr:PutImage`

## E2E Scenarios

### Public Registry, Matching Version

Create a plugin-managed EKS `1.35` cluster with autoscaling enabled and no `autoscalerImageTagOverride`.

Expected result:

- autoscaler deployment uses the latest discovered `v1.35.x` tag;
- runnable UI only reports autoscaler creation success;
- logs show the selected autoscaler tag.

Repeat with EKS `1.33`.

Expected result:

- autoscaler deployment uses the latest discovered `v1.33.x` tag;
- this proves selection is based on the cluster Kubernetes minor, not simply the newest published autoscaler tag.

### Public Registry, Missing Matching Version

Create a plugin-managed EKS `1.36` cluster with autoscaling enabled and no `autoscalerImageTagOverride`.

Expected result if no `v1.36.x` autoscaler image is published:

- registry tag discovery succeeds;
- no matching `v1.36.x` tag is selected;
- bundled fallback logic is used;
- deployment uses the latest bundled fallback tag, currently `v1.35.0`;
- fallback is visible in plugin logs only, not in the runnable UI.

### Private ECR, Explicit Override

Create or update an EKS `1.35` cluster using:

```text
autoscalerRegistryURL=$ECR_REGISTRY
autoscalerImageTagOverride=dss-qa-1_35
```

Expected result:

- autoscaler deployment uses `$ECR_REGISTRY/autoscaling/cluster-autoscaler:dss-qa-1_35`;
- no registry tag discovery is required for the override;
- the override tag does not need to follow `vX.Y.Z`.

Repeat with:

```text
autoscalerImageTagOverride=v1.35
```

Expected result:

- autoscaler deployment uses `$ECR_REGISTRY/autoscaling/cluster-autoscaler:v1.35`;
- success proves override tags are passed through as-is.

### Private ECR, No Override

Create or update an EKS `1.35` cluster using:

```text
autoscalerRegistryURL=$ECR_REGISTRY
```

Do not set `autoscalerImageTagOverride`.

Expected result:

- if the private registry does not expose a compatible `/v2/autoscaling/cluster-autoscaler/tags/list` endpoint, discovery fails;
- plugin logs mention that tag discovery failed and fallback will be used;
- bundled fallback tag for Kubernetes `1.35` is selected;
- autoscaler deployment uses `$ECR_REGISTRY/autoscaling/cluster-autoscaler:v1.35.0`;
- this preserves the existing private-registry workflow where customers mirror the expected fallback tag.

## Validation Commands

Check the deployed autoscaler image:

```bash
kubectl -n kube-system get deployment cluster-autoscaler \
  -o jsonpath='{.spec.template.spec.containers[0].image}'
```

Check autoscaler pod health:

```bash
kubectl -n kube-system get pods -l app=cluster-autoscaler
```

Check autoscaler logs:

```bash
kubectl -n kube-system logs deployment/cluster-autoscaler
```

Check plugin logs for:

- selected published tag;
- fallback to bundled tag;
- registry tag discovery failure for private ECR without override.

## Cleanup

- Delete EKS clusters and node groups created for the test.
- Delete the temporary ECR repository if it was created only for this test.
- Remove temporary IAM policies or role attachments used for pushing or pulling ECR images.

## Out Of Scope

- Legacy EKS versions below the currently supported EKS range.
- Verifying cluster autoscaler runtime behavior beyond deployment health and pod startup.
