### PR TITLE
[sc-330797][eks-clusters] Adds supported Python versions 3.13, 3.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 1.6.0 - Enhancement release - 2026-07-20
+
+- Added supported Python versions: 3.13, 3.14
+
 ## Next version
 - Improve autoscaler image version selection
 

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,5 +1,14 @@
 {
-  "acceptedPythonInterpreters": ["PYTHON37", "PYTHON38", "PYTHON39", "PYTHON310", "PYTHON311", "PYTHON312"],
+  "acceptedPythonInterpreters": [
+    "PYTHON37",
+    "PYTHON38",
+    "PYTHON39",
+    "PYTHON310",
+    "PYTHON311",
+    "PYTHON312",
+    "PYTHON313",
+    "PYTHON314"
+  ],
   "forceConda": false,
   "installCorePackages": true,
   "installJupyterSupport": false,

--- a/plugin.json
+++ b/plugin.json
@@ -1,14 +1,17 @@
 {
-    "id": "eks-clusters",
-    "version": "1.5.0",
-    "meta": {
-        "label": "EKS clusters",
-        "description": "Interact with Amazon Elastic Kubernetes Service clusters",
-        "author": "Dataiku",
-        "icon": "icon-amazon-elastic-kubernetes icon-cloud",
-        "tags": ["Infra", "AWS"],
-        "url": "https://www.dataiku.com/dss/plugins/info/eks-clusters.html",
-        "licenseInfo": "Apache Software License",
-        "supportLevel": "TIER2_SUPPORT"
-    }
+  "id": "eks-clusters",
+  "version": "1.6.0",
+  "meta": {
+    "label": "EKS clusters",
+    "description": "Interact with Amazon Elastic Kubernetes Service clusters",
+    "author": "Dataiku",
+    "icon": "icon-amazon-elastic-kubernetes icon-cloud",
+    "tags": [
+      "Infra",
+      "AWS"
+    ],
+    "url": "https://www.dataiku.com/dss/plugins/info/eks-clusters.html",
+    "licenseInfo": "Apache Software License",
+    "supportLevel": "TIER2_SUPPORT"
+  }
 }


### PR DESCRIPTION
## ⚠️⚠️⚠️ From an automated update script ⚠️⚠️⚠️

- Support level: `TIER2_SUPPORT`
- Added supported Python versions: `3.13, 3.14`
- Bumped plugin version: `1.6.0`

## Details:
### - Tests on Deployer 14.7.1:
 - Creation of Python 3.13 code-env: ✅
 - Creation of Python 3.14 code-env: ✅
### - Tests on Daily master:
 - Creation of Python 3.13 code-env: ✅
 - Creation of Python 3.14 code-env: ✅